### PR TITLE
feat(monitor): iRacing process detection (Layer 3)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod config;
 mod models;
+mod monitor;
 
 use commands::ConfigState;
 use std::sync::Mutex;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,11 +4,15 @@ mod models;
 mod monitor;
 
 use commands::ConfigState;
+use monitor::{Monitor, MonitorEvent};
 use std::sync::Mutex;
+use tauri::Emitter;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let config = config::load_config();
+    let trigger = config.settings.default_trigger.clone();
+    let poll_interval = config.settings.poll_interval_secs;
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -21,6 +25,19 @@ pub fn run() {
             commands::save_settings,
             commands::add_app,
         ])
+        .setup(move |app| {
+            let handle = app.handle().clone();
+
+            Monitor::start(trigger, poll_interval, move |event| {
+                let status = match event {
+                    MonitorEvent::Started => "online",
+                    MonitorEvent::Stopped => "offline",
+                };
+                let _ = handle.emit("iracing-status", status);
+            });
+
+            Ok(())
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,10 @@ use monitor::{Monitor, MonitorEvent};
 use std::sync::Mutex;
 use tauri::Emitter;
 
+pub const EVENT_IRACING_STATUS: &str = "iracing-status";
+pub const STATUS_ONLINE: &str = "online";
+pub const STATUS_OFFLINE: &str = "offline";
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let config = config::load_config();
@@ -30,10 +34,10 @@ pub fn run() {
 
             Monitor::start(trigger, poll_interval, move |event| {
                 let status = match event {
-                    MonitorEvent::Started => "online",
-                    MonitorEvent::Stopped => "offline",
+                    MonitorEvent::Started => STATUS_ONLINE,
+                    MonitorEvent::Stopped => STATUS_OFFLINE,
                 };
-                let _ = handle.emit("iracing-status", status);
+                let _ = handle.emit(EVENT_IRACING_STATUS, status);
             });
 
             Ok(())

--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -32,20 +32,24 @@ pub struct MonitorLogic {
 
 impl MonitorLogic {
     pub fn new(trigger: TriggerMode) -> Self {
-        todo!()
+        Self { online: false, trigger }
     }
 
     /// Feed the current observation; returns an event only on state transitions.
     pub fn tick(&mut self, is_running: bool) -> Option<MonitorEvent> {
-        todo!()
+        match (self.online, is_running) {
+            (false, true)  => { self.online = true;  Some(MonitorEvent::Started) }
+            (true,  false) => { self.online = false; Some(MonitorEvent::Stopped) }
+            _              => None,
+        }
     }
 
     pub fn is_online(&self) -> bool {
-        todo!()
+        self.online
     }
 
     pub fn trigger_process_name(&self) -> &'static str {
-        todo!()
+        process_name_for(&self.trigger)
     }
 }
 
@@ -62,12 +66,45 @@ impl Monitor {
     where
         F: Fn(MonitorEvent) + Send + 'static,
     {
-        todo!()
+        let stop_flag = Arc::new(Mutex::new(false));
+        let stop_clone = Arc::clone(&stop_flag);
+
+        let handle = thread::Builder::new()
+            .name("iracing-monitor".into())
+            .spawn(move || {
+                let mut logic = MonitorLogic::new(trigger);
+                let mut sys = System::new();
+                let interval = Duration::from_secs_f64(poll_interval_secs.max(0.25));
+
+                loop {
+                    if *stop_clone.lock().unwrap() {
+                        break;
+                    }
+
+                    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, false);
+                    let target = logic.trigger_process_name();
+                    let running = sys.processes().values().any(|p| {
+                        p.name().to_string_lossy().eq_ignore_ascii_case(target)
+                    });
+
+                    if let Some(event) = logic.tick(running) {
+                        on_event(event);
+                    }
+
+                    thread::sleep(interval);
+                }
+            })
+            .expect("failed to spawn monitor thread");
+
+        Self { handle: Some(handle), stop_flag }
     }
 
     /// Signals the thread to stop and waits for it to finish (max 3 s).
     pub fn stop(&mut self) {
-        todo!()
+        *self.stop_flag.lock().unwrap() = true;
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
     }
 }
 

--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -1,0 +1,205 @@
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use sysinfo::System;
+
+use crate::models::TriggerMode;
+
+// ── Process names ────────────────────────────────────────────────────────────
+
+pub fn process_name_for(trigger: &TriggerMode) -> &'static str {
+    match trigger {
+        TriggerMode::Ui   => "iRacingUI.exe",
+        TriggerMode::Race => "iRacingSim64DX11.exe",
+    }
+}
+
+// ── Events ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MonitorEvent {
+    Started,
+    Stopped,
+}
+
+// ── Pure state machine (fully testable without threads) ──────────────────────
+
+pub struct MonitorLogic {
+    online: bool,
+    trigger: TriggerMode,
+}
+
+impl MonitorLogic {
+    pub fn new(trigger: TriggerMode) -> Self {
+        todo!()
+    }
+
+    /// Feed the current observation; returns an event only on state transitions.
+    pub fn tick(&mut self, is_running: bool) -> Option<MonitorEvent> {
+        todo!()
+    }
+
+    pub fn is_online(&self) -> bool {
+        todo!()
+    }
+
+    pub fn trigger_process_name(&self) -> &'static str {
+        todo!()
+    }
+}
+
+// ── Thread wrapper ───────────────────────────────────────────────────────────
+
+pub struct Monitor {
+    handle: Option<JoinHandle<()>>,
+    stop_flag: Arc<Mutex<bool>>,
+}
+
+impl Monitor {
+    /// Spawns the polling thread. `on_event` is called on every state transition.
+    pub fn start<F>(trigger: TriggerMode, poll_interval_secs: f64, on_event: F) -> Self
+    where
+        F: Fn(MonitorEvent) + Send + 'static,
+    {
+        todo!()
+    }
+
+    /// Signals the thread to stop and waits for it to finish (max 3 s).
+    pub fn stop(&mut self) {
+        todo!()
+    }
+}
+
+impl Drop for Monitor {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // ── MonitorLogic: initial state ──────────────────────────────────────────
+
+    #[test]
+    fn should_start_in_offline_state() {
+        let logic = MonitorLogic::new(TriggerMode::Ui);
+        assert!(!logic.is_online());
+    }
+
+    // ── MonitorLogic: process name resolution ────────────────────────────────
+
+    #[test]
+    fn should_use_iracing_ui_process_name_for_ui_trigger() {
+        let logic = MonitorLogic::new(TriggerMode::Ui);
+        assert_eq!(logic.trigger_process_name(), "iRacingUI.exe");
+    }
+
+    #[test]
+    fn should_use_iracing_sim_process_name_for_race_trigger() {
+        let logic = MonitorLogic::new(TriggerMode::Race);
+        assert_eq!(logic.trigger_process_name(), "iRacingSim64DX11.exe");
+    }
+
+    // ── MonitorLogic: offline → online ───────────────────────────────────────
+
+    #[test]
+    fn should_emit_started_when_process_appears() {
+        let mut logic = MonitorLogic::new(TriggerMode::Ui);
+        let event = logic.tick(true);
+        assert_eq!(event, Some(MonitorEvent::Started));
+        assert!(logic.is_online());
+    }
+
+    #[test]
+    fn should_emit_no_event_while_staying_offline() {
+        let mut logic = MonitorLogic::new(TriggerMode::Ui);
+        assert_eq!(logic.tick(false), None);
+        assert_eq!(logic.tick(false), None);
+    }
+
+    // ── MonitorLogic: online → offline ───────────────────────────────────────
+
+    #[test]
+    fn should_emit_stopped_when_process_disappears() {
+        let mut logic = MonitorLogic::new(TriggerMode::Ui);
+        logic.tick(true); // → online
+        let event = logic.tick(false);
+        assert_eq!(event, Some(MonitorEvent::Stopped));
+        assert!(!logic.is_online());
+    }
+
+    #[test]
+    fn should_emit_no_event_while_staying_online() {
+        let mut logic = MonitorLogic::new(TriggerMode::Ui);
+        logic.tick(true); // → online
+        assert_eq!(logic.tick(true), None);
+        assert_eq!(logic.tick(true), None);
+    }
+
+    // ── MonitorLogic: rapid transitions ─────────────────────────────────────
+
+    #[test]
+    fn should_emit_started_and_stopped_on_rapid_transitions() {
+        let mut logic = MonitorLogic::new(TriggerMode::Race);
+        assert_eq!(logic.tick(true),  Some(MonitorEvent::Started));
+        assert_eq!(logic.tick(false), Some(MonitorEvent::Stopped));
+        assert_eq!(logic.tick(true),  Some(MonitorEvent::Started));
+        assert_eq!(logic.tick(false), Some(MonitorEvent::Stopped));
+    }
+
+    #[test]
+    fn should_not_emit_duplicate_started_on_consecutive_running_ticks() {
+        let mut logic = MonitorLogic::new(TriggerMode::Ui);
+        let first  = logic.tick(true);
+        let second = logic.tick(true);
+        let third  = logic.tick(true);
+        assert_eq!(first,  Some(MonitorEvent::Started));
+        assert_eq!(second, None);
+        assert_eq!(third,  None);
+    }
+
+    // ── process_name_for (free function) ─────────────────────────────────────
+
+    #[test]
+    fn should_resolve_ui_process_name() {
+        assert_eq!(process_name_for(&TriggerMode::Ui), "iRacingUI.exe");
+    }
+
+    #[test]
+    fn should_resolve_race_process_name() {
+        assert_eq!(process_name_for(&TriggerMode::Race), "iRacingSim64DX11.exe");
+    }
+
+    // ── Monitor thread ───────────────────────────────────────────────────────
+
+    #[test]
+    fn should_start_and_stop_monitor_thread_without_panicking() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = Arc::clone(&counter);
+
+        let mut monitor = Monitor::start(
+            TriggerMode::Ui,
+            0.05,
+            move |_event| {
+                counter_clone.fetch_add(1, Ordering::SeqCst);
+            },
+        );
+
+        std::thread::sleep(Duration::from_millis(150));
+        monitor.stop();
+        // thread stopped cleanly — no panic, no deadlock
+    }
+
+    #[test]
+    fn should_not_panic_when_stop_called_twice() {
+        let mut monitor = Monitor::start(TriggerMode::Ui, 0.05, |_| {});
+        monitor.stop();
+        monitor.stop(); // second call must be a no-op
+    }
+}

--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -8,10 +8,13 @@ use crate::models::TriggerMode;
 
 // ── Process names ────────────────────────────────────────────────────────────
 
+pub const PROCESS_IRACING_UI: &str = "iRacingUI.exe";
+pub const PROCESS_IRACING_SIM: &str = "iRacingSim64DX11.exe";
+
 pub fn process_name_for(trigger: &TriggerMode) -> &'static str {
     match trigger {
-        TriggerMode::Ui   => "iRacingUI.exe",
-        TriggerMode::Race => "iRacingSim64DX11.exe",
+        TriggerMode::Ui   => PROCESS_IRACING_UI,
+        TriggerMode::Race => PROCESS_IRACING_SIM,
     }
 }
 

--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -81,7 +81,7 @@ impl Monitor {
                         break;
                     }
 
-                    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, false);
+                    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
                     let target = logic.trigger_process_name();
                     let running = sys.processes().values().any(|p| {
                         p.name().to_string_lossy().eq_ignore_ascii_case(target)
@@ -238,5 +238,43 @@ mod tests {
         let mut monitor = Monitor::start(TriggerMode::Ui, 0.05, |_| {});
         monitor.stop();
         monitor.stop(); // second call must be a no-op
+    }
+
+    // ── Manual integration test (requires iRacing running) ──────────────────
+    //
+    // Run with:
+    //   cargo test --manifest-path src-tauri/Cargo.toml -- --ignored --nocapture
+    //
+    // Start iRacing UI before running, then close it during the 15s window to
+    // observe both Started and Stopped events.
+
+    #[test]
+    #[ignore]
+    fn manual_should_detect_real_iracing_process() {
+        use std::sync::mpsc;
+
+        let (tx, rx) = mpsc::channel::<MonitorEvent>();
+
+        println!("\n[monitor integration] Watching for iRacingUI.exe...");
+        println!("[monitor integration] Open iRacing UI, then close it. Test ends on Stopped.\n");
+
+        let mut monitor = Monitor::start(TriggerMode::Ui, 1.0, move |event| {
+            match &event {
+                MonitorEvent::Started => println!("[monitor integration] ✓ Started"),
+                MonitorEvent::Stopped => println!("[monitor integration] ✓ Stopped"),
+            }
+            let _ = tx.send(event);
+        });
+
+        loop {
+            match rx.recv_timeout(Duration::from_secs(120)) {
+                Ok(MonitorEvent::Stopped) => break,
+                Ok(MonitorEvent::Started) => continue,
+                Err(_) => { println!("[monitor integration] Timeout — no events in 120s."); break; }
+            }
+        }
+
+        monitor.stop();
+        println!("[monitor integration] Done.");
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,21 +5,20 @@ import { AppsScreen } from "@/components/screens/AppsScreen";
 import { LogScreen } from "@/components/screens/LogScreen";
 import { HistoryScreen } from "@/components/screens/HistoryScreen";
 import { SettingsScreen } from "@/components/screens/SettingsScreen";
-
-// Mock state — will be replaced by Rust IPC in Layer 3
-const MOCK_STATUS = {
-  iRacingRunning: true,
-  sessionType: "service" as const,
-  managedCount: 2,
-  paused: false,
-};
+import { useIRacingStatus } from "@/hooks/useIRacingStatus";
 
 function App() {
   const [tab, setTab] = useState<Tab>("apps");
+  const iRacingRunning = useIRacingStatus();
 
   return (
     <div className="flex flex-col h-screen bg-zinc-900">
-      <StatusBar {...MOCK_STATUS} />
+      <StatusBar
+        iRacingRunning={iRacingRunning}
+        sessionType={null}
+        managedCount={0}
+        paused={false}
+      />
 
       <div className="flex flex-1 min-h-0">
         <Sidebar active={tab} onChange={setTab} />

--- a/src/hooks/useIRacingStatus.ts
+++ b/src/hooks/useIRacingStatus.ts
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { EVENT_IRACING_STATUS, STATUS_ONLINE } from "@/lib/events";
 
 export function useIRacingStatus() {
   const [online, setOnline] = useState(false);
 
   useEffect(() => {
-    const unlisten = listen<string>("iracing-status", (event) => {
-      setOnline(event.payload === "online");
+    const unlisten = listen<string>(EVENT_IRACING_STATUS, (event) => {
+      setOnline(event.payload === STATUS_ONLINE);
     });
 
     return () => {

--- a/src/hooks/useIRacingStatus.ts
+++ b/src/hooks/useIRacingStatus.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+export function useIRacingStatus() {
+  const [online, setOnline] = useState(false);
+
+  useEffect(() => {
+    const unlisten = listen<string>("iracing-status", (event) => {
+      setOnline(event.payload === "online");
+    });
+
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  return online;
+}

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,3 @@
+export const EVENT_IRACING_STATUS = "iracing-status";
+export const STATUS_ONLINE = "online";
+export const STATUS_OFFLINE = "offline";


### PR DESCRIPTION
## Summary

- Adds `monitor.rs` with `MonitorLogic` pure state machine and `Monitor` polling thread
- `MonitorLogic::tick` emits `Started`/`Stopped` only on state transitions — no duplicate events
- `Monitor::start` spawns a named thread using `sysinfo` to poll the configured trigger process
- Process name resolved from `TriggerMode`: `iRacingUI.exe` (Ui) or `iRacingSim64DX11.exe` (Race)
- Fixed `remove_dead_processes=true` so `Stopped` is correctly emitted when iRacing closes
- Wires monitor to Tauri app via `iracing-status` event + `useIRacingStatus` hook in the frontend

## Test plan

- [x] 13 Rust unit tests: initial state, transitions, duplicate events, process name resolution, thread start/stop
- [x] 1 manual integration test (`#[ignore]`) validated with real iRacing process — both `Started` and `Stopped` confirmed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 34/34 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)