### PR TITLE
refactor(config): extract APP_NAME constant

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -3,10 +3,12 @@ use std::path::{Path, PathBuf};
 
 use crate::models::AppConfig;
 
+pub const APP_NAME: &str = "Pitlane";
+
 pub fn config_path() -> PathBuf {
     dirs::data_local_dir()
         .unwrap_or_else(|| PathBuf::from("."))
-        .join("Pitlane")
+        .join(APP_NAME)
         .join("config.json")
 }
 


### PR DESCRIPTION
## Summary

- Extracts `"Pitlane"` hardcoded in `config_path()` into a `pub const APP_NAME: &str = "Pitlane"` constant
- Motivated by review comment on [PR #1](https://github.com/rvahilario/pitlane/pull/1) about magic strings — pattern applied consistently across the codebase

## Test plan

- [x] `cargo test` — 21/21 passing, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)