### PR TITLE
feat(controller): Layer 6 — orchestrator wiring Monitor+Watchdog+Launcher+Killer

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,8 +1,9 @@
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use serde::Deserialize;
 use tauri::State;
 
 use crate::config::save_config;
+use crate::controller::{AppStatus, Controller};
 use crate::models::{AppConfig, ManagedApp, Profile, Settings};
 
 #[derive(Debug, Deserialize)]
@@ -19,7 +20,8 @@ pub struct NewApp {
     pub track_process_name: Option<String>,
 }
 
-pub struct ConfigState(pub Mutex<AppConfig>);
+pub struct ConfigState(pub Arc<Mutex<AppConfig>>);
+pub struct ControllerState(pub Arc<Controller>);
 
 pub fn apps_for_active_profile(config: &AppConfig) -> Vec<ManagedApp> {
     config
@@ -55,6 +57,21 @@ pub fn save_settings(state: State<ConfigState>, settings: Settings) -> Result<()
     let mut config = state.0.lock().unwrap();
     config.settings = settings;
     save_config(&config)
+}
+
+#[tauri::command]
+pub fn get_app_statuses(state: State<ControllerState>) -> Vec<AppStatus> {
+    state.0.app_statuses()
+}
+
+#[tauri::command]
+pub fn force_launch_app(state: State<ControllerState>, app_id: String) -> Result<(), String> {
+    state.0.force_launch(&app_id)
+}
+
+#[tauri::command]
+pub fn force_kill_app(state: State<ControllerState>, app_id: String) {
+    state.0.force_kill(&app_id);
 }
 
 #[tauri::command]

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -1,0 +1,398 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::models::{AppConfig, ManagedApp, TriggerMode};
+use crate::monitor::{Monitor, MonitorEvent};
+use crate::watchdog::{Watchdog, WatchdogEvent};
+use crate::{launcher, process_killer};
+
+const DEFAULT_GRACE_SECS: f64 = 5.0;
+
+// ── App state ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AppState {
+    Idle,
+    Running { pid: u32, restart_count: u32 },
+    Crashed,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AppStatus {
+    pub app_id: String,
+    pub name: String,
+    pub state: AppState,
+}
+
+// ── Pure state machine ────────────────────────────────────────────────────────
+
+pub struct ControllerLogic {
+    states: HashMap<String, AppState>,
+}
+
+impl ControllerLogic {
+    pub fn new() -> Self {
+        Self { states: HashMap::new() }
+    }
+
+    pub fn on_app_launched(&mut self, app_id: &str, pid: u32) {
+        self.states.insert(app_id.to_string(), AppState::Running { pid, restart_count: 0 });
+    }
+
+    pub fn on_app_stopped(&mut self, app_id: &str) {
+        self.states.insert(app_id.to_string(), AppState::Idle);
+    }
+
+    pub fn on_app_restarted(&mut self, app_id: &str, new_pid: u32, attempt: u32) {
+        self.states.insert(app_id.to_string(), AppState::Running { pid: new_pid, restart_count: attempt });
+    }
+
+    pub fn on_app_gave_up(&mut self, app_id: &str) {
+        self.states.insert(app_id.to_string(), AppState::Crashed);
+    }
+
+    pub fn app_state(&self, app_id: &str) -> AppState {
+        self.states.get(app_id).cloned().unwrap_or(AppState::Idle)
+    }
+
+    pub fn running_apps(&self) -> Vec<(String, u32)> {
+        self.states
+            .iter()
+            .filter_map(|(id, state)| {
+                if let AppState::Running { pid, .. } = state {
+                    Some((id.clone(), *pid))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+/// Returns enabled apps from the slice — those to launch on iRacing start.
+pub fn apps_to_launch(apps: &[ManagedApp]) -> Vec<&ManagedApp> {
+    apps.iter().filter(|a| a.enabled).collect()
+}
+
+// ── Controller ────────────────────────────────────────────────────────────────
+
+pub struct Controller {
+    logic: Arc<Mutex<ControllerLogic>>,
+    watchdog: Arc<Watchdog>,
+    config: Arc<Mutex<AppConfig>>,
+}
+
+impl Controller {
+    /// Starts the controller: wires Monitor → launch/kill, Watchdog → state updates.
+    /// `on_status(true)` is called when iRacing starts; `on_status(false)` when it stops.
+    /// Returns an `Arc<Controller>` ready to be stored as Tauri state.
+    pub fn start(
+        config: Arc<Mutex<AppConfig>>,
+        trigger: TriggerMode,
+        poll_interval: f64,
+        on_status: impl Fn(bool) + Send + 'static,
+    ) -> Arc<Self> {
+        let (watchdog, watchdog_rx) = Watchdog::new();
+        let ctrl = Arc::new(Self {
+            logic: Arc::new(Mutex::new(ControllerLogic::new())),
+            watchdog: Arc::new(watchdog),
+            config,
+        });
+
+        // Thread: consume watchdog events and update logic state
+        let ctrl_wd = Arc::clone(&ctrl);
+        thread::spawn(move || {
+            for event in watchdog_rx {
+                match event {
+                    WatchdogEvent::Restarted { app_id, new_pid, attempt } => {
+                        ctrl_wd.logic.lock().unwrap().on_app_restarted(&app_id, new_pid, attempt);
+                    }
+                    WatchdogEvent::GaveUp { app_id } | WatchdogEvent::RestartFailed { app_id } => {
+                        ctrl_wd.logic.lock().unwrap().on_app_gave_up(&app_id);
+                    }
+                }
+            }
+        });
+
+        // Monitor callback — spawns threads so the monitor is never blocked
+        let ctrl_mon = Arc::clone(&ctrl);
+        Monitor::start(trigger, poll_interval, move |event| {
+            match event {
+                MonitorEvent::Started => {
+                    on_status(true);
+                    let c = Arc::clone(&ctrl_mon);
+                    thread::spawn(move || c.launch_active_apps());
+                }
+                MonitorEvent::Stopped => {
+                    on_status(false);
+                    let c = Arc::clone(&ctrl_mon);
+                    thread::spawn(move || c.kill_all_running());
+                }
+            }
+        });
+
+        ctrl
+    }
+
+    // ── iRacing lifecycle ─────────────────────────────────────────────────────
+
+    fn launch_active_apps(&self) {
+        let apps: Vec<ManagedApp> = {
+            let config = self.config.lock().unwrap();
+            let profile_id = &config.active_profile_id.clone();
+            apps_to_launch(&config.apps)
+                .into_iter()
+                .filter(|a| &a.profile_id == profile_id)
+                .cloned()
+                .collect()
+        };
+
+        for app in apps {
+            // Skip if already running (e.g. manual launch before iRacing started)
+            if matches!(
+                self.logic.lock().unwrap().app_state(&app.id),
+                AppState::Running { .. }
+            ) {
+                continue;
+            }
+
+            let logic = Arc::clone(&self.logic);
+            let watchdog = Arc::clone(&self.watchdog);
+
+            thread::spawn(move || {
+                if app.startup_delay_secs > 0.0 {
+                    thread::sleep(Duration::from_secs_f64(app.startup_delay_secs));
+                }
+                match launcher::launch(&app) {
+                    Ok(stub_pid) => {
+                        let pid = launcher::resolve_real_pid(stub_pid, &app);
+                        watchdog.watch(app.clone(), pid);
+                        logic.lock().unwrap().on_app_launched(&app.id, pid);
+                    }
+                    Err(e) => eprintln!("[controller] Failed to launch '{}': {e}", app.name),
+                }
+            });
+        }
+    }
+
+    fn kill_all_running(&self) {
+        let running = self.logic.lock().unwrap().running_apps();
+        for (app_id, pid) in running {
+            self.watchdog.unwatch(&app_id);
+            process_killer::graceful_kill(pid, DEFAULT_GRACE_SECS);
+            self.logic.lock().unwrap().on_app_stopped(&app_id);
+        }
+    }
+
+    // ── Public API (for Tauri commands) ───────────────────────────────────────
+
+    /// Current status of all apps in the active profile.
+    pub fn app_statuses(&self) -> Vec<AppStatus> {
+        let config = self.config.lock().unwrap();
+        let logic = self.logic.lock().unwrap();
+        config
+            .apps
+            .iter()
+            .filter(|a| a.profile_id == config.active_profile_id)
+            .map(|a| AppStatus {
+                app_id: a.id.clone(),
+                name: a.name.clone(),
+                state: logic.app_state(&a.id),
+            })
+            .collect()
+    }
+
+    /// Manually launches an app regardless of iRacing state.
+    pub fn force_launch(&self, app_id: &str) -> Result<(), String> {
+        let app = {
+            let config = self.config.lock().unwrap();
+            config.apps.iter().find(|a| a.id == app_id).cloned()
+        };
+        let app = app.ok_or_else(|| format!("App not found: {app_id}"))?;
+
+        if matches!(self.logic.lock().unwrap().app_state(app_id), AppState::Running { .. }) {
+            return Ok(());
+        }
+
+        let stub_pid = launcher::launch(&app).map_err(|e| e.to_string())?;
+        let pid = launcher::resolve_real_pid(stub_pid, &app);
+        self.watchdog.watch(app.clone(), pid);
+        self.logic.lock().unwrap().on_app_launched(app_id, pid);
+        Ok(())
+    }
+
+    /// Manually kills an app and stops watching it.
+    pub fn force_kill(&self, app_id: &str) {
+        let pid = match self.logic.lock().unwrap().app_state(app_id) {
+            AppState::Running { pid, .. } => pid,
+            _ => return,
+        };
+        self.watchdog.unwatch(app_id);
+        process_killer::graceful_kill(pid, DEFAULT_GRACE_SECS);
+        self.logic.lock().unwrap().on_app_stopped(app_id);
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::ManagedApp;
+
+    // ── apps_to_launch ────────────────────────────────────────────────────────
+
+    #[test]
+    fn should_return_only_enabled_apps() {
+        let mut a = ManagedApp::new("p1", "SimHub", "SimHub.exe");
+        let mut b = ManagedApp::new("p1", "CrewChief", "CrewChief.exe");
+        let c = ManagedApp::new("p1", "VoiceAttack", "VoiceAttack.exe");
+        a.enabled = false;
+        b.enabled = true;
+        // c.enabled is true by default
+
+        let apps = [a, b, c];
+        let result = apps_to_launch(&apps);
+        assert_eq!(result.len(), 2);
+        assert!(result.iter().all(|a| a.enabled));
+    }
+
+    #[test]
+    fn should_return_empty_when_all_apps_disabled() {
+        let mut a = ManagedApp::new("p1", "SimHub", "SimHub.exe");
+        a.enabled = false;
+        assert!(apps_to_launch(&[a]).is_empty());
+    }
+
+    #[test]
+    fn should_return_empty_for_empty_input() {
+        assert!(apps_to_launch(&[]).is_empty());
+    }
+
+    #[test]
+    fn should_return_all_when_all_enabled() {
+        let apps = vec![
+            ManagedApp::new("p1", "SimHub", "SimHub.exe"),
+            ManagedApp::new("p1", "CrewChief", "CrewChief.exe"),
+        ];
+        assert_eq!(apps_to_launch(&apps).len(), 2);
+    }
+
+    // ── ControllerLogic: default state ────────────────────────────────────────
+
+    #[test]
+    fn should_default_to_idle_for_unknown_app() {
+        let logic = ControllerLogic::new();
+        assert_eq!(logic.app_state("ghost"), AppState::Idle);
+    }
+
+    // ── ControllerLogic: launch ───────────────────────────────────────────────
+
+    #[test]
+    fn should_transition_to_running_on_launch() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("app1", 1234);
+        assert_eq!(logic.app_state("app1"), AppState::Running { pid: 1234, restart_count: 0 });
+    }
+
+    #[test]
+    fn should_have_zero_restart_count_after_initial_launch() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("app1", 1234);
+        assert_eq!(logic.app_state("app1"), AppState::Running { pid: 1234, restart_count: 0 });
+    }
+
+    // ── ControllerLogic: stop ─────────────────────────────────────────────────
+
+    #[test]
+    fn should_transition_to_idle_on_stop() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("app1", 1234);
+        logic.on_app_stopped("app1");
+        assert_eq!(logic.app_state("app1"), AppState::Idle);
+    }
+
+    #[test]
+    fn should_stay_idle_when_stopping_a_not_running_app() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_stopped("app1");
+        assert_eq!(logic.app_state("app1"), AppState::Idle);
+    }
+
+    // ── ControllerLogic: restart ──────────────────────────────────────────────
+
+    #[test]
+    fn should_update_pid_and_count_on_restart() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("app1", 1000);
+        logic.on_app_restarted("app1", 2000, 1);
+        assert_eq!(logic.app_state("app1"), AppState::Running { pid: 2000, restart_count: 1 });
+    }
+
+    #[test]
+    fn should_accumulate_restart_count_across_multiple_restarts() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("app1", 1000);
+        logic.on_app_restarted("app1", 2000, 1);
+        logic.on_app_restarted("app1", 3000, 2);
+        assert_eq!(logic.app_state("app1"), AppState::Running { pid: 3000, restart_count: 2 });
+    }
+
+    // ── ControllerLogic: gave up ──────────────────────────────────────────────
+
+    #[test]
+    fn should_transition_to_crashed_on_gave_up() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("app1", 1234);
+        logic.on_app_gave_up("app1");
+        assert_eq!(logic.app_state("app1"), AppState::Crashed);
+    }
+
+    #[test]
+    fn should_recover_from_crashed_to_running_on_relaunch() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_gave_up("app1");
+        logic.on_app_launched("app1", 5678);
+        assert_eq!(logic.app_state("app1"), AppState::Running { pid: 5678, restart_count: 0 });
+    }
+
+    // ── ControllerLogic: running_apps ─────────────────────────────────────────
+
+    #[test]
+    fn should_return_only_running_app_pids() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("app1", 100);
+        logic.on_app_launched("app2", 200);
+        logic.on_app_stopped("app1");
+
+        let running = logic.running_apps();
+        assert_eq!(running.len(), 1);
+        assert_eq!(running[0], ("app2".to_string(), 200));
+    }
+
+    #[test]
+    fn should_return_empty_running_apps_when_none_active() {
+        let logic = ControllerLogic::new();
+        assert!(logic.running_apps().is_empty());
+    }
+
+    // ── ControllerLogic: state isolation ──────────────────────────────────────
+
+    #[test]
+    fn should_track_multiple_apps_independently() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("simhub", 100);
+        logic.on_app_launched("crewchief", 200);
+        logic.on_app_stopped("simhub");
+
+        assert_eq!(logic.app_state("simhub"), AppState::Idle);
+        assert_eq!(logic.app_state("crewchief"), AppState::Running { pid: 200, restart_count: 0 });
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,15 +1,15 @@
 mod commands;
 mod config;
+mod controller;
 mod launcher;
 mod models;
 mod monitor;
 mod process_killer;
 mod watchdog;
 
-use commands::ConfigState;
-use monitor::{Monitor, MonitorEvent};
-use std::sync::Mutex;
-use tauri::Emitter;
+use commands::{ConfigState, ControllerState};
+use std::sync::{Arc, Mutex};
+use tauri::{Emitter, Manager};
 
 pub const EVENT_IRACING_STATUS: &str = "iracing-status";
 pub const STATUS_ONLINE: &str = "online";
@@ -20,10 +20,25 @@ pub fn run() {
     let config = config::load_config();
     let trigger = config.settings.default_trigger.clone();
     let poll_interval = config.settings.poll_interval_secs;
+    let config_arc = Arc::new(Mutex::new(config));
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .manage(ConfigState(Mutex::new(config)))
+        .manage(ConfigState(Arc::clone(&config_arc)))
+        .setup(move |app| {
+            let handle = app.handle().clone();
+            let ctrl = controller::Controller::start(
+                Arc::clone(&config_arc),
+                trigger,
+                poll_interval,
+                move |online| {
+                    let status = if online { STATUS_ONLINE } else { STATUS_OFFLINE };
+                    let _ = handle.emit(EVENT_IRACING_STATUS, status);
+                },
+            );
+            app.manage(ControllerState(ctrl));
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             commands::get_profiles,
             commands::get_apps,
@@ -31,20 +46,10 @@ pub fn run() {
             commands::get_active_profile_id,
             commands::save_settings,
             commands::add_app,
+            commands::get_app_statuses,
+            commands::force_launch_app,
+            commands::force_kill_app,
         ])
-        .setup(move |app| {
-            let handle = app.handle().clone();
-
-            Monitor::start(trigger, poll_interval, move |event| {
-                let status = match event {
-                    MonitorEvent::Started => STATUS_ONLINE,
-                    MonitorEvent::Stopped => STATUS_OFFLINE,
-                };
-                let _ = handle.emit(EVENT_IRACING_STATUS, status);
-            });
-
-            Ok(())
-        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -45,6 +45,17 @@ export interface NewApp {
   track_process_name?: string;
 }
 
+export type AppStateType =
+  | { type: "idle" }
+  | { type: "running"; pid: number; restart_count: number }
+  | { type: "crashed" };
+
+export interface AppStatus {
+  app_id: string;
+  name: string;
+  state: AppStateType;
+}
+
 export const api = {
   getProfiles: () => invoke<Profile[]>("get_profiles"),
   getApps: () => invoke<ManagedApp[]>("get_apps"),
@@ -52,4 +63,7 @@ export const api = {
   getActiveProfileId: () => invoke<string>("get_active_profile_id"),
   saveSettings: (settings: Settings) => invoke<void>("save_settings", { settings }),
   addApp: (app: NewApp) => invoke<ManagedApp>("add_app", { app }),
+  getAppStatuses: () => invoke<AppStatus[]>("get_app_statuses"),
+  forceLaunchApp: (appId: string) => invoke<void>("force_launch_app", { appId }),
+  forceKillApp: (appId: string) => invoke<void>("force_kill_app", { appId }),
 };


### PR DESCRIPTION
## Summary

- `ControllerLogic`: pure state machine (`Idle / Running / Crashed`) — testable without threads or real processes
- `Controller::start`: orchestrates Monitor → launch/kill threads + Watchdog → state updates via channel
- `on_iracing_started`: spawns one thread per app respecting `startup_delay_secs`, skips already-running apps
- `on_iracing_stopped`: `graceful_kill` all running apps (5s grace) + unwatch from watchdog
- `ConfigState` upgraded to `Arc<Mutex<AppConfig>>` shared between Controller and commands
- New commands: `get_app_statuses`, `force_launch_app`, `force_kill_app`
- `api.ts`: `AppStatus` type + three new command wrappers

## Test plan

- [x] 16 new tests — `ControllerLogic` state machine + `apps_to_launch`
- [x] 95 total tests passing, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)