### PR TITLE
test(controller): integration tests with fixture binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Pitlane monitora o iRacing e gerencia automaticamente o ciclo de vida de apps co
 | 0 — Scaffold | ✅ |
 | 1 — UI Shell | ✅ |
 | 2 — Models + Config + Commands | ✅ |
-| 3 — Monitor (iRacing detection) | 🔄 |
-| 4 — Launcher + Process Killer | ⬜ |
-| 5 — Controller | ⬜ |
-| 6 — Watchdog | ⬜ |
-| 7 — CRUD completo | ⬜ |
-| 8 — Tray + Single Instance | ⬜ |
-| 9 — Autostart + Import/Export | ⬜ |
+| 3 — Monitor (iRacing detection) | ✅ |
+| 4 — Launcher + Process Killer | ✅ |
+| 5 — Watchdog (crash detection + auto-restart) | ✅ |
+| 6 — Controller (orchestrator) | ✅ |
+| 7 — Tray + Single Instance | ⬜ |
+| 8 — Autostart | ⬜ |
+| 9 — UI wired to controller (app statuses) | ⬜ |
 | 10 — Build | ⬜ |
 
 ## Desenvolvimento
@@ -46,8 +46,12 @@ npm run dev
 # Testes frontend
 npm run test
 
-# Testes Rust
+# Testes Rust (unitários)
 cargo test --manifest-path src-tauri/Cargo.toml
+
+# Testes de integração (requer build dos fixtures primeiro)
+cargo build --bins --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml -- --ignored --nocapture
 ```
 
 ## Requisitos

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,3 +33,14 @@ windows = { version = "0.58", features = [
 ] }
 log = "0.4"
 
+[[bin]]
+name = "fixture-dummy"
+path = "tests/fixtures/dummy.rs"
+
+[[bin]]
+name = "fixture-crash"
+path = "tests/fixtures/crash.rs"
+
+[[bin]]
+name = "fixture-stub"
+path = "tests/fixtures/stub.rs"

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -143,7 +143,7 @@ impl Controller {
 
     // ── iRacing lifecycle ─────────────────────────────────────────────────────
 
-    fn launch_active_apps(&self) {
+    pub(crate) fn launch_active_apps(&self) {
         let apps: Vec<ManagedApp> = {
             let config = self.config.lock().unwrap();
             let profile_id = &config.active_profile_id.clone();
@@ -182,7 +182,7 @@ impl Controller {
         }
     }
 
-    fn kill_all_running(&self) {
+    pub(crate) fn kill_all_running(&self) {
         let running = self.logic.lock().unwrap().running_apps();
         for (app_id, pid) in running {
             self.watchdog.unwatch(&app_id);
@@ -394,5 +394,142 @@ mod tests {
 
         assert_eq!(logic.app_state("simhub"), AppState::Idle);
         assert_eq!(logic.app_state("crewchief"), AppState::Running { pid: 200, restart_count: 0 });
+    }
+
+    // ── E2E integration tests ─────────────────────────────────────────────────
+    //
+    // Require fixture binaries to be built first:
+    //   cargo build --bins --manifest-path src-tauri/Cargo.toml
+    //
+    // Run with:
+    //   cargo test --manifest-path src-tauri/Cargo.toml -- --ignored --nocapture
+
+    fn fixture(name: &str) -> String {
+        let dir = env!("CARGO_MANIFEST_DIR");
+        format!("{dir}\\target\\debug\\{name}.exe")
+    }
+
+    fn make_controller(app: ManagedApp) -> Arc<Controller> {
+        use std::sync::{Arc, Mutex};
+        let mut config = AppConfig::default();
+        let profile_id = config.active_profile_id.clone();
+        let mut app = app;
+        app.profile_id = profile_id;
+        config.apps.push(app);
+        Controller::start(Arc::new(Mutex::new(config)), TriggerMode::Ui, 1.0, |_| {})
+    }
+
+    #[test]
+    #[ignore]
+    fn manual_e2e_should_launch_and_kill_dummy_app() {
+        let app = ManagedApp::new("p1", "Dummy", fixture("fixture-dummy"));
+        let app_id = app.id.clone();
+        let ctrl = make_controller(app);
+
+        ctrl.launch_active_apps();
+        // resolve_real_pid sleeps 500ms inside the spawned thread; give it margin
+        std::thread::sleep(std::time::Duration::from_millis(1500));
+
+        let state = ctrl.logic.lock().unwrap().app_state(&app_id);
+        let pid = match state {
+            AppState::Running { pid, .. } => { println!("[e2e] launched pid={pid}"); pid }
+            other => panic!("[e2e] expected Running, got {other:?}"),
+        };
+
+        assert!(process_killer::is_pid_alive(pid), "dummy should be alive");
+
+        ctrl.kill_all_running();
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        assert!(!process_killer::is_pid_alive(pid), "dummy should be dead after kill");
+        assert_eq!(ctrl.logic.lock().unwrap().app_state(&app_id), AppState::Idle);
+        println!("[e2e] ✓ launch and kill");
+    }
+
+    #[test]
+    #[ignore]
+    fn manual_e2e_should_skip_already_running_app_on_iracing_start() {
+        let app = ManagedApp::new("p1", "Dummy", fixture("fixture-dummy"));
+        let app_id = app.id.clone();
+        let ctrl = make_controller(app);
+
+        // Simulate user manually launching the app before iRacing starts
+        ctrl.force_launch(&app_id).expect("force_launch failed");
+        std::thread::sleep(std::time::Duration::from_millis(800));
+
+        let pid_before = match ctrl.logic.lock().unwrap().app_state(&app_id) {
+            AppState::Running { pid, .. } => { println!("[e2e] manual launch pid={pid}"); pid }
+            other => panic!("[e2e] expected Running after force_launch, got {other:?}"),
+        };
+
+        // iRacing starts — should NOT re-launch an already running app
+        ctrl.launch_active_apps();
+        std::thread::sleep(std::time::Duration::from_millis(800));
+
+        let pid_after = match ctrl.logic.lock().unwrap().app_state(&app_id) {
+            AppState::Running { pid, .. } => pid,
+            other => panic!("[e2e] expected still Running after launch_active_apps, got {other:?}"),
+        };
+
+        assert_eq!(pid_before, pid_after, "PID must not change — app was already running");
+        println!("[e2e] ✓ already-running app not re-launched (pid unchanged: {pid_before})");
+
+        ctrl.kill_all_running();
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        assert!(!process_killer::is_pid_alive(pid_before), "dummy should be dead");
+        println!("[e2e] ✓ killed");
+    }
+
+    #[test]
+    #[ignore]
+    fn manual_e2e_should_restart_crashing_app_then_give_up() {
+        let mut app = ManagedApp::new("p1", "Crash", fixture("fixture-crash"));
+        app.restart_on_crash = true;
+        app.max_restart_attempts = 2;
+        let app_id = app.id.clone();
+        let ctrl = make_controller(app);
+
+        ctrl.launch_active_apps();
+
+        // Watchdog polls every 2s; with 2 restart attempts we need ~3 cycles
+        // Wait long enough for all retries to exhaust
+        let wait = std::time::Duration::from_secs(10);
+        println!("[e2e] waiting {wait:?} for watchdog to exhaust restarts…");
+        std::thread::sleep(wait);
+
+        let state = ctrl.logic.lock().unwrap().app_state(&app_id);
+        assert_eq!(state, AppState::Crashed, "app should be Crashed after max attempts");
+        println!("[e2e] ✓ app reached Crashed state after {attempts} failed restarts",
+            attempts = 2);
+    }
+
+    #[test]
+    #[ignore]
+    fn manual_e2e_should_resolve_real_pid_from_stub_launcher() {
+        // fixture-stub spawns fixture-dummy then exits immediately.
+        // track_process_name tells the controller to find the real process by name.
+        let mut app = ManagedApp::new("p1", "Stub", fixture("fixture-stub"));
+        app.track_process_name = Some("fixture-dummy.exe".into());
+        let app_id = app.id.clone();
+        let ctrl = make_controller(app);
+
+        ctrl.launch_active_apps();
+        // Give stub time to spawn child and resolve_real_pid to find it
+        std::thread::sleep(std::time::Duration::from_millis(1500));
+
+        let pid = match ctrl.logic.lock().unwrap().app_state(&app_id) {
+            AppState::Running { pid, .. } => { println!("[e2e] resolved child pid={pid}"); pid }
+            other => panic!("[e2e] expected Running with child pid, got {other:?}"),
+        };
+
+        // The tracked PID must be fixture-dummy (alive), not fixture-stub (dead)
+        assert!(process_killer::is_pid_alive(pid), "resolved pid should be alive (fixture-dummy)");
+        assert!(!process_killer::find_pids_by_name("fixture-stub").contains(&pid),
+            "tracked pid must not be the stub");
+
+        ctrl.kill_all_running();
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        assert!(!process_killer::is_pid_alive(pid), "fixture-dummy should be dead after kill");
+        println!("[e2e] ✓ stub pid resolved to child, child killed");
     }
 }

--- a/src-tauri/tests/fixtures/crash.rs
+++ b/src-tauri/tests/fixtures/crash.rs
@@ -1,0 +1,4 @@
+// Fixture: crashing app — exits immediately to simulate a crash.
+fn main() {
+    std::process::exit(1);
+}

--- a/src-tauri/tests/fixtures/dummy.rs
+++ b/src-tauri/tests/fixtures/dummy.rs
@@ -1,0 +1,6 @@
+// Fixture: persistent dummy app — just stays alive until killed.
+fn main() {
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}

--- a/src-tauri/tests/fixtures/stub.rs
+++ b/src-tauri/tests/fixtures/stub.rs
@@ -1,0 +1,15 @@
+// Fixture: stub launcher — spawns fixture-dummy as a child then exits immediately.
+// Simulates Squirrel-style launchers that hand off to a child process.
+fn main() {
+    let self_dir = std::env::current_exe()
+        .expect("cannot resolve current exe")
+        .parent()
+        .expect("exe has no parent dir")
+        .to_path_buf();
+
+    let dummy = self_dir.join("fixture-dummy.exe");
+    std::process::Command::new(&dummy)
+        .spawn()
+        .unwrap_or_else(|e| panic!("failed to spawn fixture-dummy at {}: {e}", dummy.display()));
+    // exits immediately — stub handed off to child
+}


### PR DESCRIPTION
## Summary

Adds three fixture binaries and four integration tests that exercise the full controller lifecycle without requiring iRacing or any third-party software.

**Fixture binaries** (`cargo build --bins` to compile):
| Binary | Behavior |
|---|---|
| `fixture-dummy` | Loops forever — represents a healthy companion app |
| `fixture-crash` | Exits immediately with code 1 — simulates a crash |
| `fixture-stub` | Spawns `fixture-dummy` then exits — simulates a Squirrel-style stub launcher |

**Scenarios covered:**
| Test | What it verifies |
|---|---|
| `manual_should_launch_and_kill_dummy_app` | App launched on iRacing start, killed on iRacing stop, state returns to Idle |
| `manual_should_skip_already_running_app_on_iracing_start` | `force_launch` before iRacing start → same PID retained, not re-launched |
| `manual_should_restart_crashing_app_then_give_up` | Watchdog retries `max_restart_attempts` times, then sets state to Crashed |
| `manual_should_resolve_real_pid_from_stub_launcher` | Stub exits immediately → real child PID resolved via `track_process_name` → child killed correctly |

## How to run

```bash
cargo build --bins --manifest-path src-tauri/Cargo.toml
cargo test --manifest-path src-tauri/Cargo.toml -- --ignored --nocapture
```

## Test plan

- [x] All 4 integration tests passing
- [x] 95 unit tests still passing, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)