### PR TITLE
feat(autostart): Layer 8 - Windows autostart via registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Pitlane monitora o iRacing e gerencia automaticamente o ciclo de vida de apps co
 | 3 — Monitor (iRacing detection) | ✅ |
 | 4 — Launcher + Process Killer | ✅ |
 | 5 — Watchdog (crash detection + auto-restart) | ✅ |
-| 6 — Controller (orchestrator) | ✅ |
-| 7 — Tray + Single Instance | ⬜ |
-| 8 — Autostart | ⬜ |
+| 6 — Controller (orchestrator) + integration tests | ✅ |
+| 7 — Tray + Single Instance | ✅ |
+| 8 — Autostart (Windows registry) | ✅ |
 | 9 — UI wired to controller (app statuses) | ⬜ |
-| 10 — Build | ⬜ |
+| 10 — Build + installer | ⬜ |
 
 ## Desenvolvimento
 
@@ -43,13 +43,16 @@ npm run tauri dev
 # Dev só frontend (sem compilar Rust)
 npm run dev
 
+# Build Rust incremental
+npm run rust:build
+
+# Testes Rust (unitários)
+npm run rust:test
+
 # Testes frontend
 npm run test
 
-# Testes Rust (unitários)
-cargo test --manifest-path src-tauri/Cargo.toml
-
-# Testes de integração (requer build dos fixtures primeiro)
+# Testes de integração Rust (requer build dos fixtures primeiro)
 cargo build --bins --manifest-path src-tauri/Cargo.toml
 cargo test --manifest-path src-tauri/Cargo.toml -- --ignored --nocapture
 ```

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "tauri": "tauri",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "rust:build": "cargo build --manifest-path src-tauri/Cargo.toml",
+    "rust:test": "cargo test --manifest-path src-tauri/Cargo.toml"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -208,6 +208,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +744,15 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
@@ -747,6 +767,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -887,7 +918,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2687,6 +2718,7 @@ dependencies = [
  "sysinfo",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "uuid",
@@ -3852,6 +3884,20 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5391,6 +5437,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ windows = { version = "0.58", features = [
     "Win32_System_Diagnostics_ToolHelp",
 ] }
 log = "0.4"
+tauri-plugin-autostart = "2"
 
 [[bin]]
 name = "fixture-dummy"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,7 +1,8 @@
 use std::sync::{Arc, Mutex};
 use serde::Deserialize;
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, State};
 use tauri::menu::{Menu, MenuItem};
+use tauri_plugin_autostart::ManagerExt;
 
 use crate::config::save_config;
 use crate::controller::{AppStatus, Controller};
@@ -23,6 +24,14 @@ pub struct NewApp {
 
 pub struct ConfigState(pub Arc<Mutex<AppConfig>>);
 pub struct ControllerState(pub Arc<Controller>);
+
+pub fn autostart_changed(old: &Settings, new: &Settings) -> Option<bool> {
+    if old.autostart != new.autostart {
+        Some(new.autostart)
+    } else {
+        None
+    }
+}
 
 pub fn apps_for_active_profile(config: &AppConfig) -> Vec<ManagedApp> {
     config
@@ -54,10 +63,22 @@ pub fn get_active_profile_id(state: State<ConfigState>) -> String {
 }
 
 #[tauri::command]
-pub fn save_settings(state: State<ConfigState>, settings: Settings) -> Result<(), String> {
+pub fn save_settings(app: AppHandle, state: State<ConfigState>, settings: Settings) -> Result<(), String> {
     let mut config = state.0.lock().unwrap();
+    if let Some(enabled) = autostart_changed(&config.settings, &settings) {
+        if enabled {
+            app.autolaunch().enable().map_err(|e| e.to_string())?;
+        } else {
+            app.autolaunch().disable().map_err(|e| e.to_string())?;
+        }
+    }
     config.settings = settings;
     save_config(&config)
+}
+
+#[tauri::command]
+pub fn get_autostart_enabled(app: AppHandle) -> Result<bool, String> {
+    app.autolaunch().is_enabled().map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -109,6 +130,48 @@ pub fn add_app(state: State<ConfigState>, app: NewApp) -> Result<ManagedApp, Str
 mod tests {
     use super::*;
     use crate::models::ManagedApp;
+
+    // ── autostart_changed ─────────────────────────────────────────────────────
+
+    #[test]
+    fn autostart_changed_returns_none_when_unchanged() {
+        let s = Settings::default(); // autostart: false
+        assert_eq!(autostart_changed(&s, &s.clone()), None);
+    }
+
+    #[test]
+    fn autostart_changed_returns_none_when_both_true() {
+        let s = Settings { autostart: true, ..Settings::default() };
+        assert_eq!(autostart_changed(&s, &s.clone()), None);
+    }
+
+    #[test]
+    fn autostart_changed_returns_some_true_when_enabled() {
+        let old = Settings { autostart: false, ..Settings::default() };
+        let new = Settings { autostart: true, ..Settings::default() };
+        assert_eq!(autostart_changed(&old, &new), Some(true));
+    }
+
+    #[test]
+    fn autostart_changed_returns_some_false_when_disabled() {
+        let old = Settings { autostart: true, ..Settings::default() };
+        let new = Settings { autostart: false, ..Settings::default() };
+        assert_eq!(autostart_changed(&old, &new), Some(false));
+    }
+
+    // ── manual integration test (needs Windows registry) ─────────────────────
+
+    /// cargo test -p pitlane -- autostart_registry --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn autostart_registry_key_is_created_and_removed() {
+        // This test requires a running Tauri app with the autostart plugin — not
+        // callable in unit-test context. Verify manually via regedit:
+        //   HKCU\Software\Microsoft\Windows\CurrentVersion\Run\pitlane
+        // Enable: save_settings with autostart=true → key should appear.
+        // Disable: save_settings with autostart=false → key should disappear.
+        println!("Run the app, toggle autostart in Settings, and verify the registry key.");
+    }
 
     fn config_with_two_profiles() -> AppConfig {
         let mut config = AppConfig::default();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ use tauri::{
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     Emitter, Manager, WindowEvent,
 };
+use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 
 pub const EVENT_IRACING_STATUS: &str = "iracing-status";
 
@@ -32,9 +33,11 @@ pub fn run() {
     let config = config::load_config();
     let trigger = config.settings.default_trigger.clone();
     let poll_interval = config.settings.poll_interval_secs;
+    let autostart = config.settings.autostart;
     let config_arc = Arc::new(Mutex::new(config));
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_autostart::init(MacosLauncher::LaunchAgent, None))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
             // Second instance tried to open — bring existing window to front
@@ -71,6 +74,14 @@ pub fn run() {
                     }
                 })
                 .build(app)?;
+
+            // ── Autostart sync ───────────────────────────────────────────────
+            // Sync registry to match config (handles installs/reinstalls)
+            if autostart {
+                let _ = app.autolaunch().enable();
+            } else {
+                let _ = app.autolaunch().disable();
+            }
 
             // ── Controller ───────────────────────────────────────────────────
             let handle = app.handle().clone();
@@ -110,6 +121,7 @@ pub fn run() {
             commands::force_launch_app,
             commands::force_kill_app,
             commands::set_tray_labels,
+            commands::get_autostart_enabled,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/__tests__/SettingsScreen.test.tsx
+++ b/src/__tests__/SettingsScreen.test.tsx
@@ -60,8 +60,8 @@ describe("SettingsScreen", () => {
     render(<SettingsScreen />);
     await screen.findByRole("spinbutton");
 
-    const toggles = screen.getAllByRole("button");
-    const autostartToggle = toggles.find((b) => b.closest("div")?.textContent?.includes("Start with Windows"));
+    const autostartToggle = screen.getAllByRole("switch")
+      .find((b) => b.closest("div")?.textContent?.includes("Start with Windows"));
     expect(autostartToggle).toBeDefined();
 
     await userEvent.click(autostartToggle!);

--- a/src/components/screens/SettingsScreen.tsx
+++ b/src/components/screens/SettingsScreen.tsx
@@ -136,11 +136,13 @@ function ToggleRow({
         <p className="text-xs text-text-disabled">{description}</p>
       </div>
       <button
+        role="switch"
+        aria-checked={enabled}
         onClick={() => onChange(!enabled)}
-        className={`w-10 h-5 rounded-full relative transition-colors ${enabled ? "bg-accent/30 border border-accent/50" : "bg-elevated border border-border-strong"}`}
+        className={`relative w-10 h-5 rounded-full transition-colors overflow-hidden ${enabled ? "bg-accent/60" : "bg-zinc-600"}`}
       >
         <span
-          className={`absolute top-0.5 w-4 h-4 rounded-full transition-transform ${enabled ? "translate-x-5 bg-accent" : "translate-x-0.5 bg-text-muted"}`}
+          className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${enabled ? "translate-x-5" : "translate-x-0"}`}
         />
       </button>
     </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -68,4 +68,5 @@ export const api = {
   forceKillApp: (appId: string) => invoke<void>("force_kill_app", { appId }),
   setTrayLabels: (showLabel: string, quitLabel: string) =>
     invoke<void>("set_tray_labels", { showLabel, quitLabel }),
+  getAutostartEnabled: () => invoke<boolean>("get_autostart_enabled"),
 };


### PR DESCRIPTION
## Summary

- Integrates `tauri-plugin-autostart` to wire the Settings toggle to the Windows registry (`HKCU\...\Run`)
- On save, `save_settings` calls `enable()`/`disable()` only when the value actually changes (via pure `autostart_changed()` function)
- On boot, registry is synced to match persisted config (handles reinstalls)
- Adds `get_autostart_enabled` command to read current registry state from frontend
- Fixes toggle visual overflow (`overflow-hidden` + explicit `left-0.5` on thumb)

## Test plan

- [x] Unit tests: `autostart_changed()` — None when unchanged, Some(true/false) on change (4 tests)
- [x] Manual: enable toggle → `HKCU\...\Run\pitlane` key appears
- [x] Manual: disable toggle → key removed
- [x] Manual: boot sync verified (key reconciled on startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)