### PR TITLE
feat(ui/screens): Layer 9 - wire AppsScreen to controller

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,23 +7,27 @@ import { LogScreen } from "@/components/screens/LogScreen";
 import { HistoryScreen } from "@/components/screens/HistoryScreen";
 import { SettingsScreen } from "@/components/screens/SettingsScreen";
 import { useIRacingStatus } from "@/hooks/useIRacingStatus";
+import { useAppStatuses } from "@/hooks/useAppStatuses";
 import { api } from "@/lib/api";
 
 function App() {
   const [tab, setTab] = useState<Tab>("apps");
   const iRacingRunning = useIRacingStatus();
+  const statuses = useAppStatuses();
   const { t, i18n } = useTranslation();
 
   useEffect(() => {
     api.setTrayLabels(t("tray.show"), t("tray.quit")).catch(() => {});
   }, [i18n.language]);
 
+  const managedCount = statuses.filter((s) => s.state.type === "running").length;
+
   return (
     <div className="flex flex-col h-screen bg-zinc-900">
       <StatusBar
         iRacingRunning={iRacingRunning}
         sessionType={null}
-        managedCount={0}
+        managedCount={managedCount}
         paused={false}
       />
 

--- a/src/__tests__/AddAppFlow.test.tsx
+++ b/src/__tests__/AddAppFlow.test.tsx
@@ -26,6 +26,7 @@ const mockApp: ManagedApp = {
   restart_on_crash: true,
   max_restart_attempts: 3,
   startup_delay_secs: 0,
+  track_process_name: null,
 };
 
 const newApp: ManagedApp = {
@@ -40,6 +41,7 @@ const newApp: ManagedApp = {
   restart_on_crash: true,
   max_restart_attempts: 3,
   startup_delay_secs: 0,
+  track_process_name: null,
 };
 
 beforeEach(() => {
@@ -47,6 +49,7 @@ beforeEach(() => {
   vi.mocked(api.getProfiles).mockResolvedValue([mockProfile]);
   vi.mocked(api.getActiveProfileId).mockResolvedValue("profile-1");
   vi.mocked(api.addApp).mockResolvedValue(newApp);
+  vi.mocked(api.getAppStatuses).mockResolvedValue([]);
 });
 
 describe("Add app flow", () => {

--- a/src/__tests__/AppsScreen.test.tsx
+++ b/src/__tests__/AppsScreen.test.tsx
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { AppsScreen } from "@/components/screens/AppsScreen";
-import type { ManagedApp, Profile } from "@/lib/api";
+import type { AppStatus, ManagedApp, Profile } from "@/lib/api";
 
 vi.mock("@/lib/api", () => ({
   api: {
     getApps: vi.fn(),
     getProfiles: vi.fn(),
     getActiveProfileId: vi.fn(),
+    getAppStatuses: vi.fn(),
+    forceLaunchApp: vi.fn(),
+    forceKillApp: vi.fn(),
   },
 }));
 
@@ -28,14 +32,22 @@ function makeApp(overrides: Partial<ManagedApp> = {}): ManagedApp {
     restart_on_crash: false,
     max_restart_attempts: 3,
     startup_delay_secs: 0,
+    track_process_name: null,
     ...overrides,
   };
+}
+
+function makeStatus(app_id: string, state: AppStatus["state"]): AppStatus {
+  return { app_id, name: "SimHub", state };
 }
 
 beforeEach(() => {
   vi.mocked(api.getProfiles).mockResolvedValue([PROFILE_A]);
   vi.mocked(api.getActiveProfileId).mockResolvedValue("p1");
   vi.mocked(api.getApps).mockResolvedValue([]);
+  vi.mocked(api.getAppStatuses).mockResolvedValue([]);
+  vi.mocked(api.forceLaunchApp).mockResolvedValue(undefined);
+  vi.mocked(api.forceKillApp).mockResolvedValue(undefined);
 });
 
 describe("AppsScreen", () => {
@@ -71,5 +83,51 @@ describe("AppsScreen", () => {
     render(<AppsScreen />);
     const item = await screen.findByText("SimHub");
     expect(item.closest("li")).toHaveClass("opacity-40");
+  });
+
+  it("should show start button when app is idle", async () => {
+    vi.mocked(api.getApps).mockResolvedValue([makeApp({ id: "1" })]);
+    vi.mocked(api.getAppStatuses).mockResolvedValue([makeStatus("1", { type: "idle" })]);
+    render(<AppsScreen />);
+    await screen.findByText("SimHub");
+    expect(screen.getByTitle(/start/i)).toBeInTheDocument();
+  });
+
+  it("should show stop button when app is running", async () => {
+    vi.mocked(api.getApps).mockResolvedValue([makeApp({ id: "1" })]);
+    vi.mocked(api.getAppStatuses).mockResolvedValue([
+      makeStatus("1", { type: "running", pid: 1234, restart_count: 0 }),
+    ]);
+    render(<AppsScreen />);
+    await screen.findByText("SimHub");
+    await waitFor(() => expect(screen.getByTitle(/stop/i)).toBeInTheDocument());
+  });
+
+  it("should show start button when app has crashed", async () => {
+    vi.mocked(api.getApps).mockResolvedValue([makeApp({ id: "1" })]);
+    vi.mocked(api.getAppStatuses).mockResolvedValue([makeStatus("1", { type: "crashed" })]);
+    render(<AppsScreen />);
+    await screen.findByText("SimHub");
+    await waitFor(() => expect(screen.getByTitle(/start/i)).toBeInTheDocument());
+  });
+
+  it("should call forceLaunchApp when start is clicked", async () => {
+    vi.mocked(api.getApps).mockResolvedValue([makeApp({ id: "42" })]);
+    vi.mocked(api.getAppStatuses).mockResolvedValue([makeStatus("42", { type: "idle" })]);
+    render(<AppsScreen />);
+    await waitFor(() => expect(screen.getByTitle(/start/i)).toBeInTheDocument());
+    await userEvent.click(screen.getByTitle(/start/i));
+    expect(vi.mocked(api.forceLaunchApp)).toHaveBeenCalledWith("42");
+  });
+
+  it("should call forceKillApp when stop is clicked", async () => {
+    vi.mocked(api.getApps).mockResolvedValue([makeApp({ id: "42" })]);
+    vi.mocked(api.getAppStatuses).mockResolvedValue([
+      makeStatus("42", { type: "running", pid: 99, restart_count: 0 }),
+    ]);
+    render(<AppsScreen />);
+    await waitFor(() => expect(screen.getByTitle(/stop/i)).toBeInTheDocument());
+    await userEvent.click(screen.getByTitle(/stop/i));
+    expect(vi.mocked(api.forceKillApp)).toHaveBeenCalledWith("42");
   });
 });

--- a/src/components/screens/AppsScreen.tsx
+++ b/src/components/screens/AppsScreen.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
-import { Plus, Play, LayoutList, X } from "lucide-react";
+import { Plus, Play, Square, LayoutList, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
-import { api, type ManagedApp, type Profile } from "@/lib/api";
+import { api, type AppStatus, type ManagedApp, type Profile } from "@/lib/api";
+import { useAppStatuses } from "@/hooks/useAppStatuses";
 
 function AddAppModal({ onClose, onAdded }: { onClose: () => void; onAdded: (app: ManagedApp) => void }) {
   const { t } = useTranslation();
@@ -86,11 +87,19 @@ function AddAppModal({ onClose, onAdded }: { onClose: () => void; onAdded: (app:
   );
 }
 
+function statusDot(status: AppStatus | undefined): string {
+  if (!status) return "bg-zinc-600";
+  if (status.state.type === "running") return "bg-green-500";
+  if (status.state.type === "crashed") return "bg-accent";
+  return "bg-zinc-600";
+}
+
 export function AppsScreen() {
   const { t } = useTranslation();
   const [apps, setApps] = useState<ManagedApp[]>([]);
   const [activeProfile, setActiveProfile] = useState<Profile | null>(null);
   const [showAddModal, setShowAddModal] = useState(false);
+  const statuses = useAppStatuses();
 
   function loadApps() {
     return Promise.all([api.getApps(), api.getProfiles(), api.getActiveProfileId()]).then(
@@ -136,30 +145,45 @@ export function AppsScreen() {
         </div>
       ) : (
         <ul className="flex flex-col gap-2">
-          {apps.map((app) => (
-            <li
-              key={app.id}
-              className={cn(
-                "flex items-center gap-3 px-3 py-2.5 rounded-lg border bg-surface transition-all",
-                "border-border-strong",
-                !app.enabled && "opacity-40",
-              )}
-            >
-              <div className="w-2 h-2 rounded-full shrink-0 bg-elevated" />
-
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-text truncate">{app.name}</p>
-                <p className="text-xs text-text-muted truncate font-mono">{app.exe_path}</p>
-              </div>
-
-              <button
-                title={t("apps.start")}
-                className="p-1.5 rounded transition-colors text-text-muted hover:text-text-secondary hover:bg-elevated"
+          {apps.map((app) => {
+            const status = statuses.find((s) => s.app_id === app.id);
+            const running = status?.state.type === "running";
+            return (
+              <li
+                key={app.id}
+                className={cn(
+                  "flex items-center gap-3 px-3 py-2.5 rounded-lg border bg-surface transition-all",
+                  "border-border-strong",
+                  !app.enabled && "opacity-40",
+                )}
               >
-                <Play className="w-3.5 h-3.5" />
-              </button>
-            </li>
-          ))}
+                <div className={cn("w-2 h-2 rounded-full shrink-0 transition-colors", statusDot(status))} />
+
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-text truncate">{app.name}</p>
+                  <p className="text-xs text-text-muted truncate font-mono">{app.exe_path}</p>
+                </div>
+
+                {running ? (
+                  <button
+                    title={t("apps.stop")}
+                    onClick={() => api.forceKillApp(app.id)}
+                    className="p-1.5 rounded transition-colors text-text-muted hover:text-accent hover:bg-elevated"
+                  >
+                    <Square className="w-3.5 h-3.5" />
+                  </button>
+                ) : (
+                  <button
+                    title={t("apps.start")}
+                    onClick={() => api.forceLaunchApp(app.id)}
+                    className="p-1.5 rounded transition-colors text-text-muted hover:text-text-secondary hover:bg-elevated"
+                  >
+                    <Play className="w-3.5 h-3.5" />
+                  </button>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
 

--- a/src/hooks/useAppStatuses.ts
+++ b/src/hooks/useAppStatuses.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+import { api, type AppStatus } from "@/lib/api";
+
+export function useAppStatuses(): AppStatus[] {
+  const [statuses, setStatuses] = useState<AppStatus[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const s = await api.getAppStatuses();
+        if (!cancelled) setStatuses(s);
+      } catch {}
+    }
+
+    poll();
+    const id = setInterval(poll, 800);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  return statuses;
+}


### PR DESCRIPTION
## Summary

- Add `useAppStatuses` hook that polls `get_app_statuses` every 800ms
- Each app card shows a colored status dot: green (running), red (crashed), gray (idle)
- Start/Stop button per app driven by state: Play → `force_launch_app`, Square → `force_kill_app`
- `App.tsx` computes real running count from statuses and passes it to `StatusBar`

## Test plan

- [x] 22 frontend tests passing (AppsScreen, AddAppFlow, SettingsScreen)
- [x] TypeScript build clean
- [x] New tests: idle/running/crashed state renders correct button, click dispatches correct API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)