### PR TITLE
fix(runtime): fix app lifecycle bugs found in real-world testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Pitlane monitora o iRacing e gerencia automaticamente o ciclo de vida de apps co
 | 6 — Controller (orchestrator) + integration tests | ✅ |
 | 7 — Tray + Single Instance | ✅ |
 | 8 — Autostart (Windows registry) | ✅ |
-| 9 — UI wired to controller (app statuses) | ⬜ |
+| 9 — UI wired to controller (app statuses) | ✅ |
 | 10 — Build + installer | ⬜ |
 
 ## Desenvolvimento

--- a/scripts/fake-iracing.ps1
+++ b/scripts/fake-iracing.ps1
@@ -1,0 +1,17 @@
+# Starts a dummy process named iRacingUI.exe to simulate iRacing being online.
+# Run this script, wait for Pitlane to launch your apps, then close this window to simulate iRacing exit.
+
+$fake = "$env:TEMP\iRacingUI.exe"
+
+# Copy cmd.exe as iRacingUI.exe so it has the right process name
+Copy-Item "$env:SystemRoot\System32\cmd.exe" $fake -Force
+
+Write-Host "iRacing (fake) starting..." -ForegroundColor Cyan
+Write-Host "Close this window to simulate iRacing exit." -ForegroundColor Yellow
+
+$proc = Start-Process $fake -ArgumentList "/K echo [fake iRacing] Running. Close this window to stop." -PassThru
+
+$proc.WaitForExit()
+
+Write-Host "iRacing (fake) stopped." -ForegroundColor Red
+Remove-Item $fake -ErrorAction SilentlyContinue

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -95,6 +95,11 @@ pub fn set_tray_labels(app: AppHandle, show_label: String, quit_label: String) -
 }
 
 #[tauri::command]
+pub fn get_iracing_status(state: State<ControllerState>) -> bool {
+    state.0.is_iracing_online()
+}
+
+#[tauri::command]
 pub fn get_app_statuses(state: State<ControllerState>) -> Vec<AppStatus> {
     state.0.app_statuses()
 }

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
@@ -72,6 +73,17 @@ impl ControllerLogic {
             })
             .collect()
     }
+
+    /// IDs of apps that were launched but are now in Crashed state
+    /// (e.g. Squirrel stub exited, real process running under a different PID).
+    pub fn crashed_app_ids(&self) -> Vec<String> {
+        self.states
+            .iter()
+            .filter_map(|(id, state)| {
+                if *state == AppState::Crashed { Some(id.clone()) } else { None }
+            })
+            .collect()
+    }
 }
 
 // ── Pure helpers ──────────────────────────────────────────────────────────────
@@ -87,6 +99,8 @@ pub struct Controller {
     logic: Arc<Mutex<ControllerLogic>>,
     watchdog: Arc<Watchdog>,
     config: Arc<Mutex<AppConfig>>,
+    iracing_online: Arc<std::sync::atomic::AtomicBool>,
+    _monitor: std::sync::OnceLock<Monitor>,
 }
 
 impl Controller {
@@ -99,11 +113,14 @@ impl Controller {
         poll_interval: f64,
         on_status: impl Fn(bool) + Send + 'static,
     ) -> Arc<Self> {
+        let iracing_online = Arc::new(AtomicBool::new(false));
         let (watchdog, watchdog_rx) = Watchdog::new();
         let ctrl = Arc::new(Self {
             logic: Arc::new(Mutex::new(ControllerLogic::new())),
             watchdog: Arc::new(watchdog),
             config,
+            iracing_online: Arc::clone(&iracing_online),
+            _monitor: std::sync::OnceLock::new(),
         });
 
         // Thread: consume watchdog events and update logic state
@@ -123,22 +140,30 @@ impl Controller {
 
         // Monitor callback — spawns threads so the monitor is never blocked
         let ctrl_mon = Arc::clone(&ctrl);
-        Monitor::start(trigger, poll_interval, move |event| {
+        let monitor = Monitor::start(trigger, poll_interval, move |event| {
             match event {
                 MonitorEvent::Started => {
+                    iracing_online.store(true, Ordering::Relaxed);
                     on_status(true);
                     let c = Arc::clone(&ctrl_mon);
                     thread::spawn(move || c.launch_active_apps());
                 }
                 MonitorEvent::Stopped => {
+                    iracing_online.store(false, Ordering::Relaxed);
                     on_status(false);
                     let c = Arc::clone(&ctrl_mon);
                     thread::spawn(move || c.kill_all_running());
                 }
             }
         });
+        // Keep the monitor alive for the lifetime of the controller
+        let _ = ctrl._monitor.set(monitor);
 
         ctrl
+    }
+
+    pub fn is_iracing_online(&self) -> bool {
+        self.iracing_online.load(Ordering::Relaxed)
     }
 
     // ── iRacing lifecycle ─────────────────────────────────────────────────────
@@ -147,12 +172,20 @@ impl Controller {
         let apps: Vec<ManagedApp> = {
             let config = self.config.lock().unwrap();
             let profile_id = &config.active_profile_id.clone();
-            apps_to_launch(&config.apps)
+            let all = apps_to_launch(&config.apps);
+            println!("[controller] iRacing started — active_profile={profile_id}, enabled_apps={}", all.len());
+            let filtered: Vec<ManagedApp> = all
                 .into_iter()
                 .filter(|a| &a.profile_id == profile_id)
                 .cloned()
-                .collect()
+                .collect();
+            println!("[controller] apps to launch for profile: {}", filtered.iter().map(|a| a.name.as_str()).collect::<Vec<_>>().join(", "));
+            filtered
         };
+
+        if apps.is_empty() {
+            println!("[controller] no apps to launch (list empty or all already running)");
+        }
 
         for app in apps {
             // Skip if already running (e.g. manual launch before iRacing started)
@@ -160,33 +193,71 @@ impl Controller {
                 self.logic.lock().unwrap().app_state(&app.id),
                 AppState::Running { .. }
             ) {
+                println!("[controller] skipping '{}' — already running", app.name);
                 continue;
             }
 
+            println!("[controller] spawning launch thread for '{}'", app.name);
             let logic = Arc::clone(&self.logic);
             let watchdog = Arc::clone(&self.watchdog);
 
             thread::spawn(move || {
                 if app.startup_delay_secs > 0.0 {
+                    println!("[controller] '{}' delay={:.1}s", app.name, app.startup_delay_secs);
                     thread::sleep(Duration::from_secs_f64(app.startup_delay_secs));
                 }
+                println!("[controller] launching '{}' at '{}'", app.name, app.exe_path);
                 match launcher::launch(&app) {
                     Ok(stub_pid) => {
+                        println!("[controller] '{}' stub_pid={stub_pid}", app.name);
                         let pid = launcher::resolve_real_pid(stub_pid, &app);
+                        println!("[controller] '{}' resolved pid={pid}", app.name);
                         watchdog.watch(app.clone(), pid);
                         logic.lock().unwrap().on_app_launched(&app.id, pid);
                     }
-                    Err(e) => eprintln!("[controller] Failed to launch '{}': {e}", app.name),
+                    Err(e) => eprintln!("[controller] FAILED to launch '{}': {e}", app.name),
                 }
             });
         }
     }
 
     pub(crate) fn kill_all_running(&self) {
-        let running = self.logic.lock().unwrap().running_apps();
-        for (app_id, pid) in running {
+        // Log all app states at kill time to diagnose tracking issues
+        {
+            let logic = self.logic.lock().unwrap();
+            let config = self.config.lock().unwrap();
+            for app in &config.apps {
+                if app.profile_id == config.active_profile_id {
+                    println!("[controller] kill_all_running state: '{}' = {:?}", app.name, logic.app_state(&app.id));
+                }
+            }
+        }
+
+        let ids_to_kill: Vec<String> = {
+            let logic = self.logic.lock().unwrap();
+            let mut ids: Vec<String> = logic.running_apps().into_iter().map(|(id, _)| id).collect();
+            // Also kill Crashed apps — the stub may have exited (e.g. Squirrel) while the
+            // real process is still running under a different PID.
+            ids.extend(logic.crashed_app_ids());
+            ids
+        };
+
+        for app_id in ids_to_kill {
             self.watchdog.unwatch(&app_id);
-            process_killer::graceful_kill(pid, DEFAULT_GRACE_SECS);
+
+            // Re-resolve at kill time: apps may have relaunched under a new PID since launch
+            if let Some(app) = self.config.lock().unwrap().apps.iter().find(|a| a.id == app_id).cloned() {
+                let grace = if app.force_kill_on_stop { 0.0 } else { DEFAULT_GRACE_SECS };
+                println!("[controller] killing '{}' grace={grace}s tree={}", app.name, app.kill_process_tree);
+                if let Some(ref name) = app.track_process_name {
+                    process_killer::kill_by_name(name, grace);
+                } else if app.kill_process_tree {
+                    process_killer::kill_tree_by_exe_path(&app.exe_path, grace);
+                } else {
+                    process_killer::kill_by_exe_path(&app.exe_path, grace);
+                }
+            }
+
             self.logic.lock().unwrap().on_app_stopped(&app_id);
         }
     }
@@ -230,12 +301,19 @@ impl Controller {
 
     /// Manually kills an app and stops watching it.
     pub fn force_kill(&self, app_id: &str) {
-        let pid = match self.logic.lock().unwrap().app_state(app_id) {
-            AppState::Running { pid, .. } => pid,
-            _ => return,
-        };
+        if !matches!(self.logic.lock().unwrap().app_state(app_id), AppState::Running { .. }) {
+            return;
+        }
         self.watchdog.unwatch(app_id);
-        process_killer::graceful_kill(pid, DEFAULT_GRACE_SECS);
+
+        if let Some(app) = self.config.lock().unwrap().apps.iter().find(|a| a.id == app_id).cloned() {
+            if let Some(ref name) = app.track_process_name {
+                process_killer::kill_by_name(name, DEFAULT_GRACE_SECS);
+            } else {
+                process_killer::kill_by_exe_path(&app.exe_path, DEFAULT_GRACE_SECS);
+            }
+        }
+
         self.logic.lock().unwrap().on_app_stopped(app_id);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -117,6 +117,7 @@ pub fn run() {
             commands::get_active_profile_id,
             commands::save_settings,
             commands::add_app,
+            commands::get_iracing_status,
             commands::get_app_statuses,
             commands::force_launch_app,
             commands::force_kill_app,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -34,6 +34,14 @@ pub struct ManagedApp {
     /// so the controller can find and kill it on iRacing exit.
     #[serde(default)]
     pub track_process_name: Option<String>,
+    /// Skip WM_CLOSE and go straight to TerminateProcess on stop.
+    /// Use for apps with broken shutdown handlers (e.g. OBS 32.x crashes on WM_CLOSE).
+    #[serde(default)]
+    pub force_kill_on_stop: bool,
+    /// Also kill all child processes spawned by this app on stop.
+    /// Use for apps that spawn helper processes (e.g. G Hub spawns multiple lghub.exe).
+    #[serde(default)]
+    pub kill_process_tree: bool,
 }
 
 impl ManagedApp {
@@ -51,6 +59,8 @@ impl ManagedApp {
             max_restart_attempts: 3,
             startup_delay_secs: 0.0,
             track_process_name: None,
+            force_kill_on_stop: false,
+            kill_process_tree: false,
         }
     }
 }

--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -72,12 +73,17 @@ impl Monitor {
         let stop_flag = Arc::new(Mutex::new(false));
         let stop_clone = Arc::clone(&stop_flag);
 
+        let log_path = dirs::data_local_dir()
+            .unwrap_or_else(|| std::env::temp_dir())
+            .join("Pitlane")
+            .join("debug.log");
         let handle = thread::Builder::new()
             .name("iracing-monitor".into())
             .spawn(move || {
                 let mut logic = MonitorLogic::new(trigger);
                 let mut sys = System::new();
                 let interval = Duration::from_secs_f64(poll_interval_secs.max(0.25));
+                let mut tick_count = 0u32;
 
                 loop {
                     if *stop_clone.lock().unwrap() {
@@ -86,11 +92,29 @@ impl Monitor {
 
                     sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
                     let target = logic.trigger_process_name();
+                    // target may be "iRacingUI.exe"; sysinfo on Windows may omit the extension
+                    let target_bare = target.trim_end_matches(".exe");
                     let running = sys.processes().values().any(|p| {
-                        p.name().to_string_lossy().eq_ignore_ascii_case(target)
+                        let name = p.name().to_string_lossy();
+                        name.eq_ignore_ascii_case(target) || name.eq_ignore_ascii_case(target_bare)
                     });
 
+                    // On first tick and every 10 ticks, log a sample of process names to file
+                    if tick_count % 10 == 0 {
+                        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+                            let sample: Vec<String> = sys.processes().values()
+                                .map(|p| p.name().to_string_lossy().into_owned())
+                                .filter(|n| n.to_lowercase().contains("iracing") || n.to_lowercase().contains("pitlane"))
+                                .collect();
+                            let _ = writeln!(f, "[monitor tick={tick_count}] target={target} running={running} iracing_procs={sample:?}");
+                        }
+                    }
+                    tick_count += 1;
+
                     if let Some(event) = logic.tick(running) {
+                        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+                            let _ = writeln!(f, "[monitor] EVENT={event:?} target={target}");
+                        }
                         on_event(event);
                     }
 

--- a/src-tauri/src/process_killer.rs
+++ b/src-tauri/src/process_killer.rs
@@ -85,11 +85,32 @@ pub fn kill_by_exe_path(exe_path: &str, grace_secs: f64) {
     }
 }
 
+/// Kills all processes matching `exe_path`, plus their entire child process trees.
+pub fn kill_tree_by_exe_path(exe_path: &str, grace_secs: f64) {
+    for pid in find_pids_by_exe_path(exe_path) {
+        kill_tree(pid, grace_secs);
+    }
+}
+
 /// Kills all processes matching `name` (case-insensitive).
 pub fn kill_by_name(name: &str, grace_secs: f64) {
     for pid in find_pids_by_name(name) {
         graceful_kill(pid, grace_secs);
     }
+}
+
+/// Kills a process and all its descendants using `taskkill /F /T`.
+/// Falls back to a plain force kill if taskkill fails.
+pub fn kill_tree(pid: u32, grace_secs: f64) {
+    if needs_graceful_close(grace_secs) {
+        send_wm_close(pid);
+        if wait_for_exit(pid, std::time::Duration::from_secs_f64(grace_secs)) {
+            return;
+        }
+    }
+    let _ = std::process::Command::new("taskkill")
+        .args(["/F", "/T", "/PID", &pid.to_string()])
+        .output();
 }
 
 // ── Pure helpers (fully testable) ────────────────────────────────────────────
@@ -122,12 +143,13 @@ pub fn needs_graceful_close(grace_secs: f64) -> bool {
 
 // ── Win32 helpers ─────────────────────────────────────────────────────────────
 
-/// Enumerates all top-level windows and sends WM_CLOSE to those owned by `pid`.
+/// Enumerates all top-level windows and posts WM_CLOSE to those owned by `pid`.
+/// Uses PostMessageW (async) so each app processes the close in its own event loop,
+/// avoiding race conditions when multiple windows receive WM_CLOSE simultaneously.
 pub fn send_wm_close(pid: u32) {
     use windows::Win32::Foundation::{HWND, LPARAM, BOOL};
     use windows::Win32::UI::WindowsAndMessaging::{
-        EnumWindows, GetWindowThreadProcessId, SendMessageTimeoutW,
-        SMTO_ABORTIFHUNG, WM_CLOSE,
+        EnumWindows, GetWindowThreadProcessId, PostMessageW, WM_CLOSE,
     };
 
     unsafe extern "system" fn enum_cb(hwnd: HWND, lparam: LPARAM) -> BOOL {
@@ -136,15 +158,7 @@ pub fn send_wm_close(pid: u32) {
         unsafe { GetWindowThreadProcessId(hwnd, Some(&mut window_pid)) };
         if window_pid == target_pid {
             unsafe {
-                let _ = SendMessageTimeoutW(
-                    hwnd,
-                    WM_CLOSE,
-                    None,
-                    None,
-                    SMTO_ABORTIFHUNG,
-                    2000,
-                    None,
-                );
+                let _ = PostMessageW(hwnd, WM_CLOSE, None, None);
             }
         }
         BOOL(1)

--- a/src/components/screens/AppsScreen.tsx
+++ b/src/components/screens/AppsScreen.tsx
@@ -94,6 +94,13 @@ function statusDot(status: AppStatus | undefined): string {
   return "bg-zinc-600";
 }
 
+function statusLabel(status: AppStatus | undefined): string {
+  if (!status || status.state.type === "idle") return "Idle";
+  if (status.state.type === "running") return `Running (PID ${status.state.pid})`;
+  if (status.state.type === "crashed") return "Crashed";
+  return "Unknown";
+}
+
 export function AppsScreen() {
   const { t } = useTranslation();
   const [apps, setApps] = useState<ManagedApp[]>([]);
@@ -157,7 +164,10 @@ export function AppsScreen() {
                   !app.enabled && "opacity-40",
                 )}
               >
-                <div className={cn("w-2 h-2 rounded-full shrink-0 transition-colors", statusDot(status))} />
+                <div
+                  title={statusLabel(status)}
+                  className={cn("w-2 h-2 rounded-full shrink-0 transition-colors cursor-default", statusDot(status))}
+                />
 
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-text truncate">{app.name}</p>

--- a/src/hooks/useIRacingStatus.ts
+++ b/src/hooks/useIRacingStatus.ts
@@ -1,11 +1,15 @@
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { api } from "@/lib/api";
 import { EVENT_IRACING_STATUS, STATUS_ONLINE } from "@/lib/events";
 
 export function useIRacingStatus() {
   const [online, setOnline] = useState(false);
 
   useEffect(() => {
+    // Query current state on mount — avoids missing an event fired before the listener was ready
+    api.getIRacingStatus().then(setOnline).catch(() => {});
+
     const unlisten = listen<string>(EVENT_IRACING_STATUS, (event) => {
       setOnline(event.payload === STATUS_ONLINE);
     });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -63,6 +63,7 @@ export const api = {
   getActiveProfileId: () => invoke<string>("get_active_profile_id"),
   saveSettings: (settings: Settings) => invoke<void>("save_settings", { settings }),
   addApp: (app: NewApp) => invoke<ManagedApp>("add_app", { app }),
+  getIRacingStatus: () => invoke<boolean>("get_iracing_status"),
   getAppStatuses: () => invoke<AppStatus[]>("get_app_statuses"),
   forceLaunchApp: (appId: string) => invoke<void>("force_launch_app", { appId }),
   forceKillApp: (appId: string) => invoke<void>("force_kill_app", { appId }),


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `Monitor` was dropped immediately after construction (not stored), killing the monitor thread before it could detect iRacing — apps never launched
- **Kill reliability**: switched from stale PID to `kill_by_exe_path` at kill-time; included `Crashed` apps in kill cycle so Squirrel launchers (Kapps) get their real process killed
- **OBS crash fix**: added `force_kill_on_stop` field — skips WM_CLOSE and goes straight to `TerminateProcess`, preventing the OBS 32.x destructor crash
- **G Hub fix**: added `track_process_name` support + `force_kill_on_stop` to kill `lghub.exe` by name without triggering auto-restart
- **Process tree kill**: added `kill_process_tree` field using `taskkill /F /T` for apps that spawn child processes
- **Monitor fix**: dual `.exe` matching for sysinfo cross-version compatibility; file-based debug logging to `%LOCALAPPDATA%\Pitlane\debug.log`
- **Frontend**: status dot tooltip showing app state + PID; `useIRacingStatus` mount query to avoid event race condition
- **Tooling**: `scripts/fake-iracing.ps1` to simulate iRacing open/close without launching the real sim

## Test plan

- [x] All 7 apps launch on iRacing start
- [x] All 7 apps killed on iRacing stop
- [x] OBS closes without crash (verified via absence of crash files in `obs-studio/crashes/`)
- [x] G Hub `lghub.exe` tree killed without auto-restart
- [x] Kapps (Squirrel stub) included in kill cycle
- [x] Tested using `fake-iracing.ps1` for repeatable cycle without real iRacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)