### PR TITLE
feat(controller): add per-app stop_with_iracing toggle

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -21,6 +21,9 @@ pub struct NewApp {
     pub max_restart_attempts: Option<u32>,
     pub startup_delay_secs: Option<f64>,
     pub track_process_name: Option<String>,
+    pub force_kill_on_stop: Option<bool>,
+    pub kill_process_tree: Option<bool>,
+    pub stop_with_iracing: Option<bool>,
 }
 
 impl NewApp {
@@ -34,6 +37,9 @@ impl NewApp {
         if let Some(v) = self.max_restart_attempts { managed.max_restart_attempts = v; }
         if let Some(v) = self.startup_delay_secs   { managed.startup_delay_secs = v; }
         if let Some(v) = self.track_process_name   { managed.track_process_name = non_empty(v); }
+        if let Some(v) = self.force_kill_on_stop   { managed.force_kill_on_stop = v; }
+        if let Some(v) = self.kill_process_tree    { managed.kill_process_tree = v; }
+        if let Some(v) = self.stop_with_iracing    { managed.stop_with_iracing = v; }
         managed
     }
 }
@@ -52,6 +58,7 @@ pub struct UpdateApp {
     pub track_process_name: Option<String>,
     pub force_kill_on_stop: Option<bool>,
     pub kill_process_tree: Option<bool>,
+    pub stop_with_iracing: Option<bool>,
 }
 
 impl UpdateApp {
@@ -68,6 +75,7 @@ impl UpdateApp {
         if let Some(v) = self.track_process_name   { app.track_process_name = non_empty(v); }
         if let Some(v) = self.force_kill_on_stop   { app.force_kill_on_stop = v; }
         if let Some(v) = self.kill_process_tree    { app.kill_process_tree = v; }
+        if let Some(v) = self.stop_with_iracing    { app.stop_with_iracing = v; }
     }
 }
 
@@ -317,6 +325,9 @@ mod tests {
             max_restart_attempts: None,
             startup_delay_secs: None,
             track_process_name: None,
+            force_kill_on_stop: None,
+            kill_process_tree: None,
+            stop_with_iracing: None,
         }
     }
 
@@ -358,6 +369,9 @@ mod tests {
             max_restart_attempts: Some(5),
             startup_delay_secs: Some(2.5),
             track_process_name: Some("CrewChiefV4.exe".into()),
+            force_kill_on_stop: None,
+            kill_process_tree: None,
+            stop_with_iracing: None,
         };
         let added = add_app_to(&mut config, input);
         assert_eq!(added.args, Some("--flag".into()));
@@ -402,6 +416,7 @@ mod tests {
             args: None, working_dir: None, enabled: None, start_minimized: None,
             restart_on_crash: None, max_restart_attempts: None, startup_delay_secs: None,
             track_process_name: None, force_kill_on_stop: None, kill_process_tree: None,
+            stop_with_iracing: None,
         };
         let updated = update_app_in(&mut config, &added.id, update).unwrap();
         assert_eq!(updated.name, "SimHub 2");
@@ -420,7 +435,7 @@ mod tests {
             name: None, exe_path: None, working_dir: None, enabled: None,
             start_minimized: None, restart_on_crash: None, max_restart_attempts: None,
             startup_delay_secs: None, track_process_name: None,
-            force_kill_on_stop: None, kill_process_tree: None,
+            force_kill_on_stop: None, kill_process_tree: None, stop_with_iracing: None,
         };
         let updated = update_app_in(&mut config, &id, update).unwrap();
         assert!(updated.args.is_none());
@@ -445,9 +460,57 @@ mod tests {
             exe_path: None, args: None, working_dir: None, enabled: None,
             start_minimized: None, restart_on_crash: None, max_restart_attempts: None,
             startup_delay_secs: None, track_process_name: None,
-            force_kill_on_stop: None, kill_process_tree: None,
+            force_kill_on_stop: None, kill_process_tree: None, stop_with_iracing: None,
         };
         let result = update_app_in(&mut config, "nonexistent-id", update);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn new_app_defaults_stop_with_iracing_to_true_when_omitted() {
+        let mut config = AppConfig::default();
+        let added = add_app_to(&mut config, new_app("SimHub", "SimHub.exe"));
+        assert!(added.stop_with_iracing);
+    }
+
+    #[test]
+    fn new_app_respects_stop_with_iracing_false() {
+        let mut config = AppConfig::default();
+        let input = NewApp { stop_with_iracing: Some(false), ..new_app("SimHub", "SimHub.exe") };
+        let added = add_app_to(&mut config, input);
+        assert!(!added.stop_with_iracing);
+    }
+
+    #[test]
+    fn update_app_sets_stop_with_iracing_false() {
+        let mut config = AppConfig::default();
+        let added = add_app_to(&mut config, new_app("SimHub", "SimHub.exe"));
+        assert!(added.stop_with_iracing);
+        let update = UpdateApp {
+            stop_with_iracing: Some(false),
+            name: None, exe_path: None, args: None, working_dir: None, enabled: None,
+            start_minimized: None, restart_on_crash: None, max_restart_attempts: None,
+            startup_delay_secs: None, track_process_name: None,
+            force_kill_on_stop: None, kill_process_tree: None,
+        };
+        let updated = update_app_in(&mut config, &added.id, update).unwrap();
+        assert!(!updated.stop_with_iracing);
+    }
+
+    #[test]
+    fn update_app_re_enables_stop_with_iracing() {
+        let mut config = AppConfig::default();
+        let input = NewApp { stop_with_iracing: Some(false), ..new_app("SimHub", "SimHub.exe") };
+        let added = add_app_to(&mut config, input);
+        assert!(!added.stop_with_iracing);
+        let update = UpdateApp {
+            stop_with_iracing: Some(true),
+            name: None, exe_path: None, args: None, working_dir: None, enabled: None,
+            start_minimized: None, restart_on_crash: None, max_restart_attempts: None,
+            startup_delay_secs: None, track_process_name: None,
+            force_kill_on_stop: None, kill_process_tree: None,
+        };
+        let updated = update_app_in(&mut config, &added.id, update).unwrap();
+        assert!(updated.stop_with_iracing);
     }
 }

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -306,9 +306,18 @@ impl Controller {
     pub fn kill_all_running(&self) {
         let ids_to_kill: Vec<String> = {
             let logic = self.logic.lock().unwrap();
-            let mut ids: Vec<String> = logic.running_apps().into_iter().map(|(id, _)| id).collect();
+            let config = self.config.lock().unwrap();
+            let should_stop = |id: &str| -> bool {
+                config.apps.iter().find(|a| a.id == id)
+                    .map(|a| a.stop_with_iracing)
+                    .unwrap_or(true)
+            };
+            let mut ids: Vec<String> = logic.running_apps().into_iter()
+                .map(|(id, _)| id)
+                .filter(|id| should_stop(id))
+                .collect();
             // Also kill Crashed apps — stub may have exited (Squirrel) while real process runs.
-            ids.extend(logic.crashed_app_ids());
+            ids.extend(logic.crashed_app_ids().into_iter().filter(|id| should_stop(id)));
             ids
         };
 
@@ -393,6 +402,150 @@ impl Controller {
         }
 
         self.logic.lock().unwrap().on_app_stopped(app_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_logic_with(states: Vec<(&str, AppState)>) -> ControllerLogic {
+        let mut logic = ControllerLogic::new();
+        for (id, state) in states {
+            logic.states.insert(id.to_string(), state);
+        }
+        logic
+    }
+
+    #[test]
+    fn running_apps_returns_only_running() {
+        let logic = make_logic_with(vec![
+            ("a", AppState::Running { pid: 1, restart_count: 0 }),
+            ("b", AppState::Idle),
+            ("c", AppState::Crashed),
+        ]);
+        let running: Vec<_> = logic.running_apps().iter().map(|(id, _)| id.clone()).collect();
+        assert_eq!(running, vec!["a"]);
+    }
+
+    #[test]
+    fn crashed_app_ids_returns_only_crashed() {
+        let logic = make_logic_with(vec![
+            ("a", AppState::Running { pid: 1, restart_count: 0 }),
+            ("b", AppState::Crashed),
+            ("c", AppState::Idle),
+        ]);
+        assert_eq!(logic.crashed_app_ids(), vec!["b"]);
+    }
+
+    #[test]
+    fn app_state_returns_idle_for_unknown() {
+        let logic = ControllerLogic::new();
+        assert_eq!(logic.app_state("nonexistent"), AppState::Idle);
+    }
+
+    #[test]
+    fn on_app_launched_sets_running_state() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("a", 42);
+        assert_eq!(logic.app_state("a"), AppState::Running { pid: 42, restart_count: 0 });
+    }
+
+    #[test]
+    fn on_app_stopped_sets_idle() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("a", 1);
+        logic.on_app_stopped("a");
+        assert_eq!(logic.app_state("a"), AppState::Idle);
+    }
+
+    #[test]
+    fn on_app_gave_up_sets_crashed() {
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("a", 1);
+        logic.on_app_gave_up("a");
+        assert_eq!(logic.app_state("a"), AppState::Crashed);
+    }
+
+    // ── stop_with_iracing filter ──────────────────────────────────────────────
+
+    fn make_app_with_stop(id: &str, stop_with_iracing: bool) -> crate::models::ManagedApp {
+        let mut app = crate::models::ManagedApp::new("p1", id, format!("{id}.exe"));
+        app.id = id.to_string();
+        app.stop_with_iracing = stop_with_iracing;
+        app
+    }
+
+    fn config_with_apps(apps: Vec<crate::models::ManagedApp>) -> crate::models::AppConfig {
+        let mut config = crate::models::AppConfig::default();
+        config.apps = apps;
+        config
+    }
+
+    #[test]
+    fn kill_ids_excludes_running_apps_with_stop_with_iracing_false() {
+        let app_stop = make_app_with_stop("app_stop", true);
+        let app_keep = make_app_with_stop("app_keep", false);
+        let config = config_with_apps(vec![app_stop.clone(), app_keep.clone()]);
+
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("app_stop", 1);
+        logic.on_app_launched("app_keep", 2);
+
+        let should_stop = |id: &str| -> bool {
+            config.apps.iter().find(|a| a.id == id)
+                .map(|a| a.stop_with_iracing)
+                .unwrap_or(true)
+        };
+        let ids: Vec<String> = logic.running_apps().into_iter()
+            .map(|(id, _)| id)
+            .filter(|id| should_stop(id))
+            .collect();
+
+        assert!(ids.contains(&"app_stop".to_string()));
+        assert!(!ids.contains(&"app_keep".to_string()));
+    }
+
+    #[test]
+    fn kill_ids_excludes_crashed_apps_with_stop_with_iracing_false() {
+        let app_stop = make_app_with_stop("app_stop", true);
+        let app_keep = make_app_with_stop("app_keep", false);
+        let config = config_with_apps(vec![app_stop.clone(), app_keep.clone()]);
+
+        let mut logic = ControllerLogic::new();
+        logic.on_app_gave_up("app_stop");
+        logic.on_app_gave_up("app_keep");
+
+        let should_stop = |id: &str| -> bool {
+            config.apps.iter().find(|a| a.id == id)
+                .map(|a| a.stop_with_iracing)
+                .unwrap_or(true)
+        };
+        let ids: Vec<String> = logic.crashed_app_ids().into_iter()
+            .filter(|id| should_stop(id))
+            .collect();
+
+        assert!(ids.contains(&"app_stop".to_string()));
+        assert!(!ids.contains(&"app_keep".to_string()));
+    }
+
+    #[test]
+    fn unknown_app_id_defaults_to_stop() {
+        let config = config_with_apps(vec![]);
+        let mut logic = ControllerLogic::new();
+        logic.on_app_launched("ghost_id", 99);
+
+        let should_stop = |id: &str| -> bool {
+            config.apps.iter().find(|a| a.id == id)
+                .map(|a| a.stop_with_iracing)
+                .unwrap_or(true)
+        };
+        let ids: Vec<String> = logic.running_apps().into_iter()
+            .map(|(id, _)| id)
+            .filter(|id| should_stop(id))
+            .collect();
+
+        assert!(ids.contains(&"ghost_id".to_string()));
     }
 }
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -43,6 +43,9 @@ pub struct ManagedApp {
     /// Use for apps that spawn helper processes (e.g. G Hub spawns multiple lghub.exe).
     #[serde(default)]
     pub kill_process_tree: bool,
+    /// Stop this app when iRacing closes. When false, the app keeps running after iRacing exits.
+    #[serde(default = "default_true")]
+    pub stop_with_iracing: bool,
 }
 
 impl ManagedApp {
@@ -62,6 +65,7 @@ impl ManagedApp {
             track_process_name: None,
             force_kill_on_stop: false,
             kill_process_tree: false,
+            stop_with_iracing: true,
         }
     }
 }
@@ -259,5 +263,31 @@ mod tests {
         assert!(!app.restart_on_crash);
         assert_eq!(app.max_restart_attempts, 3);
         assert_eq!(app.startup_delay_secs, 0.0);
+    }
+
+    #[test]
+    fn should_default_stop_with_iracing_to_true() {
+        let app = ManagedApp::new("p1", "SimHub", "SimHub.exe");
+        assert!(app.stop_with_iracing);
+    }
+
+    #[test]
+    fn should_deserialize_stop_with_iracing_as_true_when_missing() {
+        // Backward compat: configs saved before this field existed must default to true
+        let json = r#"{
+            "id": "abc", "profile_id": "p1",
+            "name": "SimHub", "exe_path": "SimHub.exe"
+        }"#;
+        let app: ManagedApp = serde_json::from_str(json).unwrap();
+        assert!(app.stop_with_iracing);
+    }
+
+    #[test]
+    fn should_round_trip_stop_with_iracing_false() {
+        let mut app = ManagedApp::new("p1", "SimHub", "SimHub.exe");
+        app.stop_with_iracing = false;
+        let json = serde_json::to_string(&app).unwrap();
+        let restored: ManagedApp = serde_json::from_str(&json).unwrap();
+        assert!(!restored.stop_with_iracing);
     }
 }

--- a/src/__tests__/AppsScreen.test.tsx
+++ b/src/__tests__/AppsScreen.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@/lib/api", () => ({
     forceKillApp: vi.fn(),
     getAutoStop: vi.fn(),
     setAutoStop: vi.fn(),
+    updateApp: vi.fn(),
   },
 }));
 
@@ -37,6 +38,7 @@ function makeApp(overrides: Partial<ManagedApp> = {}): ManagedApp {
     track_process_name: null,
     force_kill_on_stop: false,
     kill_process_tree: false,
+    stop_with_iracing: true,
     ...overrides,
   };
 }
@@ -54,6 +56,7 @@ beforeEach(() => {
   vi.mocked(api.forceKillApp).mockResolvedValue(undefined);
   vi.mocked(api.getAutoStop).mockResolvedValue(true);
   vi.mocked(api.setAutoStop).mockResolvedValue(undefined);
+  vi.mocked(api.updateApp).mockResolvedValue(makeApp());
 });
 
 describe("AppsScreen", () => {
@@ -124,6 +127,32 @@ describe("AppsScreen", () => {
     await waitFor(() => expect(screen.getByTitle(/start/i)).toBeInTheDocument());
     await userEvent.click(screen.getByTitle(/start/i));
     expect(vi.mocked(api.forceLaunchApp)).toHaveBeenCalledWith("42");
+  });
+
+  it("should render stop-with-iracing toggle as checked by default", async () => {
+    vi.mocked(api.getApps).mockResolvedValue([makeApp({ id: "1", stop_with_iracing: true })]);
+    render(<AppsScreen />);
+    await screen.findByText("SimHub");
+    const toggle = screen.getByRole("switch", { name: /stop with iracing/i });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("should render stop-with-iracing toggle as unchecked when false", async () => {
+    vi.mocked(api.getApps).mockResolvedValue([makeApp({ id: "1", stop_with_iracing: false })]);
+    render(<AppsScreen />);
+    await screen.findByText("SimHub");
+    const toggle = screen.getByRole("switch", { name: /stop with iracing/i });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("should call updateApp with stop_with_iracing false when toggle clicked", async () => {
+    vi.mocked(api.getApps).mockResolvedValue([makeApp({ id: "42", stop_with_iracing: true })]);
+    vi.mocked(api.updateApp).mockResolvedValue(makeApp({ id: "42", stop_with_iracing: false }));
+    render(<AppsScreen />);
+    await screen.findByText("SimHub");
+    const toggle = screen.getByRole("switch", { name: /stop with iracing/i });
+    await userEvent.click(toggle);
+    expect(vi.mocked(api.updateApp)).toHaveBeenCalledWith("42", { stop_with_iracing: false });
   });
 
   it("should call forceKillApp when stop is clicked", async () => {

--- a/src/components/AppFormModal.tsx
+++ b/src/components/AppFormModal.tsx
@@ -23,6 +23,7 @@ interface FormState {
   track_process_name: string;
   force_kill_on_stop: boolean;
   kill_process_tree: boolean;
+  stop_with_iracing: boolean;
 }
 
 function initForm(initial?: ManagedApp): FormState {
@@ -38,6 +39,7 @@ function initForm(initial?: ManagedApp): FormState {
     track_process_name:   initial?.track_process_name   ?? "",
     force_kill_on_stop:   initial?.force_kill_on_stop   ?? false,
     kill_process_tree:    initial?.kill_process_tree    ?? false,
+    stop_with_iracing:    initial?.stop_with_iracing    ?? true,
   };
 }
 
@@ -164,6 +166,7 @@ export function AppFormModal({ mode, initial, onClose, onSubmit }: AppFormModalP
         track_process_name:   form.track_process_name,
         force_kill_on_stop:   form.force_kill_on_stop,
         kill_process_tree:    form.kill_process_tree,
+        stop_with_iracing:    form.stop_with_iracing,
       });
       setSaved(true);
       setTimeout(onClose, 600);
@@ -215,6 +218,12 @@ export function AppFormModal({ mode, initial, onClose, onSubmit }: AppFormModalP
               label={t("apps.form.enabled")}
               checked={form.enabled}
               onChange={(v) => patch("enabled", v)}
+            />
+
+            <CheckRow
+              label={t("apps.auto_stop")}
+              checked={form.stop_with_iracing}
+              onChange={(v) => patch("stop_with_iracing", v)}
             />
 
             {/* ── Startup ── */}

--- a/src/components/screens/AppsScreen.tsx
+++ b/src/components/screens/AppsScreen.tsx
@@ -89,9 +89,10 @@ interface AppCardProps {
   onEdit: () => void;
   onDelete: () => void;
   onToggleEnabled: (enabled: boolean) => void;
+  onToggleStopWithIracing: (stop: boolean) => void;
 }
 
-function AppCard({ app, status, onStart, onStop, onEdit, onDelete, onToggleEnabled }: AppCardProps) {
+function AppCard({ app, status, onStart, onStop, onEdit, onDelete, onToggleEnabled, onToggleStopWithIracing }: AppCardProps) {
   const { t } = useTranslation();
   const running = status?.state.type === "running";
 
@@ -156,14 +157,24 @@ function AppCard({ app, status, onStart, onStop, onEdit, onDelete, onToggleEnabl
         </div>
       </div>
 
-      {/* Row 2: auto-start toggle */}
-      <div className="flex items-center justify-between px-3 pb-2.5 -mt-0.5">
-        <span className="text-xs text-text-muted">{t("apps.auto_start")}</span>
-        <Toggle
-          checked={app.enabled}
-          onChange={onToggleEnabled}
-          label={t("apps.auto_start")}
-        />
+      {/* Row 2: auto-start / auto-stop toggles */}
+      <div className="flex items-center justify-between px-3 pb-2.5 -mt-0.5 gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-text-muted">{t("apps.auto_start")}</span>
+          <Toggle
+            checked={app.enabled}
+            onChange={onToggleEnabled}
+            label={t("apps.auto_start")}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-text-muted">{t("apps.auto_stop")}</span>
+          <Toggle
+            checked={app.stop_with_iracing}
+            onChange={onToggleStopWithIracing}
+            label={t("apps.auto_stop")}
+          />
+        </div>
       </div>
     </li>
   );
@@ -224,6 +235,11 @@ export function AppsScreen() {
   async function handleToggleEnabled(app: ManagedApp, enabled: boolean) {
     await api.updateApp(app.id, { enabled });
     setApps((prev) => prev.map((a) => a.id === app.id ? { ...a, enabled } : a));
+  }
+
+  async function handleToggleStopWithIracing(app: ManagedApp, stop_with_iracing: boolean) {
+    await api.updateApp(app.id, { stop_with_iracing });
+    setApps((prev) => prev.map((a) => a.id === app.id ? { ...a, stop_with_iracing } : a));
   }
 
   return (
@@ -292,6 +308,7 @@ export function AppsScreen() {
                 onEdit={() => setModal({ type: "edit", app })}
                 onDelete={() => setConfirmDelete(app)}
                 onToggleEnabled={(enabled) => handleToggleEnabled(app, enabled)}
+                onToggleStopWithIracing={(stop) => handleToggleStopWithIracing(app, stop)}
               />
             );
           })}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -27,6 +27,7 @@
     "delete_confirm_message": "Remove \"{{name}}\"? This cannot be undone.",
     "delete_confirm": "Delete",
     "auto_start": "Auto-start with iRacing",
+    "auto_stop": "Stop with iRacing",
     "auto_stop_label": "Stop on close",
     "auto_stop_hint": "Stop all apps when iRacing closes",
     "status": {

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -27,6 +27,7 @@
     "delete_confirm_message": "Remover \"{{name}}\"? Esta ação não pode ser desfeita.",
     "delete_confirm": "Excluir",
     "auto_start": "Iniciar com iRacing",
+    "auto_stop": "Parar com iRacing",
     "auto_stop_label": "Parar ao fechar",
     "auto_stop_hint": "Parar todos os apps quando o iRacing fechar",
     "status": {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -15,6 +15,7 @@ export interface ManagedApp {
   track_process_name: string | null;
   force_kill_on_stop: boolean;
   kill_process_tree: boolean;
+  stop_with_iracing: boolean;
 }
 
 export interface Profile {
@@ -47,6 +48,7 @@ export interface NewApp {
   track_process_name?: string;
   force_kill_on_stop?: boolean;
   kill_process_tree?: boolean;
+  stop_with_iracing?: boolean;
 }
 
 export interface UpdateApp {
@@ -62,6 +64,7 @@ export interface UpdateApp {
   track_process_name?: string | null;
   force_kill_on_stop?: boolean;
   kill_process_tree?: boolean;
+  stop_with_iracing?: boolean;
 }
 
 export type LogKind = "launch" | "stop" | "iracing_start" | "iracing_stop";


### PR DESCRIPTION
## Summary

- Add `stop_with_iracing: bool` field to `ManagedApp` (default `true`, backward compatible with existing configs)
- `kill_all_running` now skips apps where `stop_with_iracing = false` — they keep running after iRacing closes
- Per-card toggle in `AppsScreen` and checkbox in `AppFormModal` to control the setting
- Also fix missing `force_kill_on_stop` / `kill_process_tree` fields in `NewApp` (only `UpdateApp` had them before)

## Test plan

- [ ] Add an app, disable "Stop with iRacing" toggle, start iRacing (via `fake-iracing.ps1`), close iRacing — app should keep running
- [ ] With toggle enabled (default), same flow — app should be killed as usual
- [ ] Global "Stop on close" button still works independently from per-app toggle
- [ ] Toggle state persists after app restart (saved to config.json)
- [ ] `cargo test` — all Rust unit tests pass (models serde, commands CRUD, controller filter logic)
- [ ] `npm run test` — all frontend tests pass (toggle render, click, updateApp call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)