### PR TITLE
fix(ui/theme): fix contrast ratios and color consistency (A11Y pass 1)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## Overview
+
+<!-- What problem does this PR solve? Keep this short and outcome-focused. -->
+
+## What changed
+
+<!-- Group related changes by area. Prefer bullets that describe behavior, not implementation trivia. -->
+
+### Area 1
+
+- 
+
+### Area 2
+
+- 
+
+## Why
+
+<!-- Explain the product/technical reason behind the change. Include relevant tradeoffs. -->
+
+## Screenshots / media
+
+<!-- Add screenshots or clips for UI changes. Use "N/A" when not applicable. -->
+
+## Test plan
+
+- [ ] Automated tests:
+- [ ] Build/typecheck:
+- [ ] Manual verification:
+
+## Risk and rollout notes
+
+<!-- Mention user-visible behavior changes, migration concerns, or follow-up work. -->
+
+## Review focus
+
+<!-- Tell reviewers where careful attention is most useful. -->
+

--- a/A11Y.md
+++ b/A11Y.md
@@ -1,0 +1,88 @@
+# A11y Guidelines: Accessibility as a Baseline
+
+Este documento estabelece o contexto persistente necessário para que o software **possa ser certificado** segundo as normas **WCAG 2.2 AA**, **ISO 9241-171**, **ADA** e **EAA**, dependendo de implementação rigorosa e **validação humana obrigatória**.
+
+## 0. Principle Zero: Accessibility as Pre-condition
+- Acessibilidade não é uma funcionalidade ou uma melhoria incremental; é uma **pré-condição para o uso**. 
+- Se um usuário não consegue completar uma tarefa devido a uma barreira de acessibilidade, a funcionalidade é considerada **tecnicamente quebrada**.
+- O sucesso da **Task Completion** é a nossa métrica principal de qualidade.
+
+## 1. Severity & Impact Model
+Avalie o impacto de qualquer decisão de design ou implementação seguindo estes níveis:
+- 🔴 **CRITICAL:** Falhas de **Operação**. Bloqueia a **Task Completion** ou torna a função inutilizável (Ex: Teclado quebrado, Clique em Div/Span, Modal sem gerenciamento de foco). **MUST FIX.**
+- 🟠 **HIGH:** Falhas de **Percepção e Legibilidade**. Aumenta significativamente a **Taxa de Erro ou Abandono** (Ex: Contraste insuficiente, Fontes < 12px em textos críticos, Falta de Feedback Dinâmico). **MUST FIX.**
+- 🟡 **MEDIUM:** Reduz a **Eficiência e Satisfação** (Ex: Falta de atalhos de teclado opcionais, falta de labels redundantes). **SHOULD FIX.**
+- 🔵 **LOW:** Impacto **Cosmético ou de Polimento** (Ex: Micro-interações sem aria-labels, melhorias em Focus Indicators já visíveis). **MAY FIX.**
+
+## 2. AI Behavior Contract
+Para garantir a integridade técnica, qualquer IA interagindo com este repositório **MUST**:
+- **No Inference:** Nunca inferir acessibilidade sem evidência direta no código ou especificação.
+- **Reference APG:** Priorizar padrões do [WAI-ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/).
+- **Protocol for Ambiguity:** Seguir o *Complex Component Protocol* em caso de incerteza.
+- **Explain Trade-offs:** Explicar impactos em Acessibilidade vs UX vs Negócio ao sugerir mudanças.
+- **UI Component Interrogation:** Antes de adicionar `onClick` a elementos não semânticos, a IA **MUST** propor a substituição por elementos nativos ou padrões ARIA completos.
+
+## 3. Technical Standards (POUR Framework)
+
+### Perceptível (Perceivable)
+*Referências: [Images](references/examples-images.md) | [Content & Timing](references/examples-content-interaction.md)*
+- **Contraste:** Texto **MUST** ter 4.5:1; Elementos de UI **MUST** ter 3:1. Priorizar **diferença de luminância** real (claro vs escuro) além do matiz.
+- **Alt Text:** Imagens informativas **MUST** ter descrição funcional em `alt`.
+- **Redundância Semântica:** **MUST NOT** transmitir estado apenas pela cor. O uso de **Ícones + Texto + Cor** (ex: 🔴 Erro) é o padrão obrigatório.
+- **Visual Patterns:** Gráficos e dashboards **MUST** usar texturas ou estilos de linha diferenciados para garantir distinção sem cor.
+
+### Operável (Operable)
+*Referências: [Buttons](references/examples-buttons.md) | [Modals](references/examples-modals.md) | [Navigation](references/examples-navigation.md)*
+- **Keyboard:** 100% das funcionalidades **MUST** ser operáveis sem mouse. Evite listeners puramente baseados em ponteiros sem equivalentes para eventos de teclado (`onKeyDown`).
+- **Focus:** O foco **MUST** ser visível, persistente e nunca suprimido via CSS (`outline: none` sem fallback é proibido).
+- **SPA Routing (Single Page Applications):** Após mudanças de rota baseadas no cliente (Client-side routing), o foco **MUST** ser gerenciado e resetado apropriadamente (ex: enviando foco ao topo ou um H1). Evite foco perdido na tela.
+- **Targets:** Tamanho mínimo de interação: **44x44 CSS pixels** (**MUST**).
+- **Motion:** **MUST** respeitar a query CSS de mídia `@media (prefers-reduced-motion)`. Evite animações pesadas de estado durante transições cruciais se a preferência estiver ativa.
+
+
+### Compreensível (Understandable)
+*Referências: [Forms & Errors](references/examples-forms.md) | [Content & Microcopy](references/examples-examples-content-interaction.md)*
+- **Labels:** Formulários **MUST** ter labels explícitas conectadas via `id` e `for`, ou via envelopamento de tag. Evite re-invenções que quebrem os eventos nativos do navegador.
+- **Predictability:** O comportamento de navegação **MUST** ser consistente e as interações não devem causar mudanças estruturais repentinas desanunciadas.
+- **Feedback Dinâmico:** Eventos dinâmicos baseados no estado do component (como Toasts, carregamento e sucessos de formulários em AJAX/fetch) **MUST** ser lidos ou informados ativamente através de regiões `aria-live` ou equivalentes modernos (`role="status"`, `role="alert"`).
+
+### Robusto (Robust)
+- **Semantic HTML:** **MUST** preferir elementos nativos (HTML5) a customizados.
+- **Interoperability:** O código **MUST** ser compatível com tecnologias assistivas atuais (ISO 9241-171).
+
+## 4. Visual Directives (Critérios Rígidos de UI)
+Para garantir a certificação, estas diretrizes visuais são inegociáveis:
+- **Focus Indicator:** O anel de foco **MUST** ter uma espessura mínima de 2px e um contraste de pelo menos 3:1 em relação ao fundo.
+- **Typography:** O texto **MUST NOT** ser menor que 12px.
+    - *Exceção de Densidade:* Em dashboards complexos ou metadados secundários (badges), permite-se **min 10px**, desde que o contraste seja elevado para **7:1 (WCAG AAA)** para compensar a escala.
+- **Target Spacing & Hit Area:** Elementos interativos **MUST** ter área de impacto de **44x44px**.
+    - *Compensação de Target:* Em UIs densas (ex: tabelas), se o componente visual for menor que 44px, a **hit area** (área de clique invisível) **MUST** ser expandida via CSS/padding para atingir o mínimo. Adjacentes **SHOULD** ter 8px de espaço.
+
+## 5. Complex Component Protocol
+Ao identificar um componente não mapeado ou de alta complexidade (ex: Gráficos, Grids Dinâmicos):
+1. **Identify:** Buscar padrão similar no [WAI-ARIA APG](https://www.w3.org/WAI/ARIA/apg/).
+2. **Validate:** Testar protótipo com leitor de tela (Screen Reader).
+3. **Document:** Documentar o comportamento esperado (teclado e anúncios).
+4. **Scale:** Criar um exemplo reutilizável na pasta `references/`.
+
+## 6. Anti-patterns (Do NOT do this)
+- **Clickable Divs:** **MUST NOT** usar `div` ou `span` para ações de clique. Prefira botões nativos. Se for forçado a usar, repita manualmente o comportamento de um `<button>` (`role`, `tabindex="0"`, event listener de Enter e Space).
+- **Focus Traps Vazados:** **MUST NOT** criar modais sem gerenciar o foco. Se um modal está aberto, interações com a tela de fundo devem estar estritamente bloqueadas.
+- **Placeholder Labels:** **MUST NOT** usar `placeholder` como única forma de rótulo. Instruções cruciais (como formatos de data) **MUST** estar visíveis fora do campo para evitar desaparecimento durante o preenchimento.
+- **Reinventar a Roda Complexa:** Se precisar usar componentes complexos (Select autocompletes, TreeViews, Datepickers), é fortemente recomendado usar bibliotecas robustas e acessíveis (Headless UI) a criar lógicas proprietárias do zero.
+
+## 7. Verification Workflow (Definition of Done)
+*A conformidade deve ser verificada através destas etapas (Consulte o [**Report Template**](templates/REPORT.md) para detalhes de QA final):*
+- [ ] **Technical Check:** Código limpo, testável via linter integrado (`eslint-plugin-jsx-a11y` ou similar) e passando sem violações críticas por motores como `Axe`.
+- [ ] **Tab Order:** Caminho da tecla `Tab` validado manualmente (Garante a ausência de dead-ends no frontend).
+- [ ] **User Flow:** Interações dinâmicas (SPAs) testadas quanto aos feedbacks via `aria-live` em cenários de erro e sucesso sem uso do mouse.
+- [ ] **Zoom:** Flexibilidade de UI preservada utilizando densidade relativa (Rem/Em), sendo adaptável em até 400% zoom.
+- [ ] **Color & Perception:** Sem perda funcional ao perder o uso exclusivo das cores (simuladores de deficiência de visão).
+
+---
+### 📚 Biblioteca de Referências e Modelos
+**Guia de Exemplos:** [Exemplos Práticos Antes/Depois](EXAMPLES.md)
+
+**Guias Técnicos:** [Imagens](references/examples-images.md) | [Formulários](references/examples-forms.md) | [Botões](references/examples-buttons.md) | [Modals](references/examples-modals.md) | [Navegação](references/examples-navigation.md) | [Conteúdo](references/examples-content-interaction.md) | [Percepção Visual](references/visual-perception.md) | [Governança](references/governance.md)
+
+**Templates Opcionais:** [Report de Acessibilidade](templates/REPORT.md) | [Registro de Exceções](templates/EXCEPTIONS.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ---
 
+## Acessibilidade
+
+Todo trabalho de UI neste projeto **MUST** seguir as diretrizes definidas em [`A11Y.md`](./A11Y.md).
+
+Problemas de contraste são classificados como 🟠 **HIGH** (Must Fix). Requisitos mínimos:
+- Texto: **4.5:1** contraste
+- Elementos de UI: **3:1** contraste
+- Texto mínimo: **12px** (10px apenas em metadados com contraste 7:1)
+- Targets interativos: **44×44 CSS px**
+
+---
+
 ## O que é este projeto
 
 **Pitlane** é um rewrite do [iGnition](../iGnition) em Tauri v2 (Rust backend + React frontend).

--- a/docs/A11Y-REPORT.md
+++ b/docs/A11Y-REPORT.md
@@ -1,0 +1,126 @@
+# Pitlane — A11Y Audit & Fix Checklist
+
+**Data:** 2026-04-29  
+**Padrão:** WCAG 2.2 AA · [A11Y.md](../A11Y.md)  
+**Status:** ⚠️ CONDICIONAL — fixes em progresso  
+**Referências:** `A11Y.md`, `visual-perception.md`, `examples-buttons.md`, `examples-forms.md`, `examples-modals.md`, `examples-navigation.md`, `examples-content-interaction.md`, `examples-images.md`, `governance.md`
+
+---
+
+## Progresso
+
+| Severidade | Total | Feito |
+|---|---|---|
+| 🔴 CRITICAL | 1 | 0 |
+| 🟠 HIGH | 8 | 3 |
+| 🟡 MEDIUM | 8 | 0 |
+| 🔵 LOW | 3 | 2 |
+
+---
+
+## 🔴 CRITICAL
+
+- [ ] **C1 · Focus trap ausente nos modais**  
+  `AppFormModal.tsx:181` · `ConfirmDialog.tsx:22`  
+  Teclado pode sair do modal aberto para o fundo. Inclui: focus trap + Escape key + retorno de foco ao trigger.  
+  → Ver também H6 e M8 (mesmo bloco de implementação)
+
+---
+
+## 🟠 HIGH
+
+- [x] **H1 · `text-disabled` em conteúdo legível — 2.05–2.31:1 (necessário 4.5:1)**  
+  Substituir `text-text-disabled` → `text-text-muted` em:  
+  - [x] `AppFormModal.tsx:62` — hints de campos  
+  - [x] `AppFormModal.tsx:134` — hints de CheckRow  
+  - [x] `AppFormModal.tsx:267` — label do botão "Advanced"  
+  - [x] `AppsScreen.tsx:116` — label de status (PID / Idle / Crashed)  
+  - [x] `SettingsScreen.tsx:78` — `trigger_hint`  
+  - [x] `SettingsScreen.tsx:136` — hints de `ToggleRow`  
+  - [x] `LogScreen.tsx:56` — coluna de timestamp
+
+- [x] **H2 · `SectionDivider` a 10px com `text-disabled` — 2.05:1 (necessário 7:1)**  
+  `AppFormModal.tsx:49`  
+  Fix aplicado: `text-[10px]` → `text-xs` + `text-text-disabled` → `text-text-muted`
+
+- [x] **H3 · `border-strong` falha 3:1 para bordas de controles interativos**  
+  `index.css` — `#3d2d6a` → `#8272b9` (3.23:1 sobre elevated · 3.89:1 sobre surface · 4.37:1 sobre base)  
+  `StatusBar.tsx:44` — iRacing offline pill: `border-border` → `border-border-strong`
+
+- [x] **H4 · `zinc-600` hardcoded no toggle de `SettingsScreen` — fora da paleta, falha 3:1**  
+  `SettingsScreen.tsx` — substituído por `bg-elevated border border-border-strong` + padrão consistente com `Toggle` de `AppsScreen`
+
+- [ ] **H5 · Modais sem `aria-labelledby` — leitor de tela anuncia "dialog" sem nome**  
+  `AppFormModal.tsx:182` e `ConfirmDialog.tsx:23` — adicionar `aria-labelledby="modal-title"` + `id="modal-title"` no `h3`
+
+- [ ] **H6 · Tecla Escape não fecha modais**  
+  `AppFormModal.tsx` · `ConfirmDialog.tsx` — listener `keydown → Escape` no mesmo `useEffect` do focus trap (C1)
+
+- [ ] **H7 · Erros de formulário não anunciados ao leitor de tela**  
+  `AppFormModal.tsx:298` — adicionar `role="alert"` · `aria-live="assertive"` no `<p>` de erro  
+  Adicionar `aria-invalid="true"` em inputs quando há erro
+
+- [ ] **H8 · Aba ativa no Sidebar sem `aria-current` — estado só por cor**  
+  `Sidebar.tsx:25` — adicionar `aria-current={active === id ? "page" : undefined}`
+
+---
+
+## 🟡 MEDIUM
+
+- [ ] **M1 · `text-muted` sobre `elevated` = 4.43:1 (abaixo por 0.07)**  
+  `AppFormModal.tsx:267` — confirmar background real de renderização; se `elevated`, trocar para `text-text-secondary`
+
+- [ ] **M2 · Targets interativos abaixo de 44×44px**  
+  - [ ] `AppsScreen.tsx:142` — botão Editar (~26×26px) → expandir para mín. 44px  
+  - [ ] `AppsScreen.tsx:150` — botão Excluir (~26×26px) → expandir  
+  - [ ] `AppFormModal.tsx:193` — botão fechar (~22×22px) → expandir  
+  - [ ] `HistoryScreen.tsx:56` — botão Limpar (~20×16px) → expandir
+
+- [ ] **M3 · Hints de formulário sem `aria-describedby`**  
+  `AppFormModal.tsx:57` — componente `Field`: gerar `id` para o hint e ligar ao input via `aria-describedby`
+
+- [ ] **M4 · Estado do botão autoStop comunicado só por cor**  
+  `AppsScreen.tsx:256` — adicionar `aria-pressed` ou `role="switch"` + `aria-checked`; visualmente: ícone ou texto muda com o estado
+
+- [x] **M5 · Log: `iracing_start` e `iracing_stop` com label idêntica "IRACING"**  
+  `LogScreen.tsx:14` — labels agora distintas: `"iRACING ▶"` / `"iRACING ■"`
+
+- [ ] **M6 · Botões de ícone usam `title` em vez de `aria-label`**  
+  `AppsScreen.tsx:142` (editar) · `AppsScreen.tsx:150` (excluir) — adicionar `aria-label`
+
+- [ ] **M7 · `<nav>` sem `aria-label`**  
+  `Sidebar.tsx:23` — adicionar `aria-label="Navegação principal"`
+
+- [ ] **M8 · Foco não retorna ao trigger após fechar modal**  
+  `AppFormModal.tsx` · `ConfirmDialog.tsx` — salvar `document.activeElement` antes de abrir; restaurar no `onClose`  
+  → Implementar no mesmo bloco de C1
+
+---
+
+## 🔵 LOW
+
+- [x] **L1 · `text-accent/60` para `iracing_stop` — contraste por opacidade (~4.2:1)**  
+  `LogScreen.tsx:11` — substituído por `text-accent/75`
+
+- [ ] **L2 · Sem link "Skip to content"**  
+  Adicionar `<a href="#main-content">` visível no focus antes do Sidebar
+
+- [ ] **L3 · Sem `eslint-plugin-jsx-a11y` no toolchain**  
+  `npm install --save-dev eslint-plugin-jsx-a11y` + configurar no ESLint
+
+---
+
+## O que já está correto
+
+| Item | Local |
+|---|---|
+| Todos os interativos usam `<button>` nativo | Global |
+| `StatusIndicator` tem `aria-label` nos ícones | `AppsScreen.tsx:18,23,27` |
+| `Toggle` usa `role="switch"` + `aria-checked` | `AppsScreen.tsx:63` |
+| `ToggleRow` usa `role="switch"` + `aria-checked` | `SettingsScreen.tsx:139` |
+| Formulário usa `<label htmlFor>` + `id` | `AppFormModal.tsx:209,213` |
+| Botão fechar tem `aria-label` | `AppFormModal.tsx:196` · `ConfirmDialog.tsx:34` |
+| `text` (#f0eeff) sobre `base`: 15.8:1 | `index.css` |
+| `text-muted` (#9d8cc0) sobre `base`: 6.0:1 | `index.css` |
+| `text-muted` sobre `surface`: 5.3:1 | `index.css` |
+| Sem `div`/`span` com `onClick` | Global |

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,6 +16,8 @@
         "title": "Pitlane",
         "width": 800,
         "height": 600,
+        "minWidth": 750,
+        "minHeight": 230,
         "visible": false
       }
     ],

--- a/src/__tests__/AddAppFlow.test.tsx
+++ b/src/__tests__/AddAppFlow.test.tsx
@@ -29,6 +29,7 @@ const mockApp: ManagedApp = {
   track_process_name: null,
   force_kill_on_stop: false,
   kill_process_tree: false,
+  stop_with_iracing: true,
 };
 
 const newApp: ManagedApp = {
@@ -46,6 +47,7 @@ const newApp: ManagedApp = {
   track_process_name: null,
   force_kill_on_stop: false,
   kill_process_tree: false,
+  stop_with_iracing: true,
 };
 
 beforeEach(() => {

--- a/src/__tests__/AppsScreen.test.tsx
+++ b/src/__tests__/AppsScreen.test.tsx
@@ -87,11 +87,17 @@ describe("AppsScreen", () => {
     await waitFor(() => expect(screen.getByText(/Default/)).toBeInTheDocument());
   });
 
-  it("should dim disabled apps", async () => {
+  it("should keep manual controls available when app auto-start is disabled", async () => {
     vi.mocked(api.getApps).mockResolvedValue([makeApp({ enabled: false })]);
     render(<AppsScreen />);
     const item = await screen.findByText("SimHub");
-    expect(item.closest("li")).toHaveClass("opacity-50");
+    expect(item.closest("li")).not.toHaveClass("opacity-50");
+    expect(screen.getByText(/disabled/i)).toBeInTheDocument();
+    expect(screen.getByTitle(/start/i)).not.toBeDisabled();
+    expect(screen.getByTitle(/edit/i)).not.toBeDisabled();
+    expect(screen.getByTitle(/delete/i)).not.toBeDisabled();
+    expect(screen.getByRole("switch", { name: /auto-start with iracing/i })).not.toBeDisabled();
+    expect(screen.getByRole("switch", { name: /stop with iracing/i })).toBeDisabled();
   });
 
   it("should show start button when app is idle", async () => {
@@ -153,6 +159,21 @@ describe("AppsScreen", () => {
     const toggle = screen.getByRole("switch", { name: /stop with iracing/i });
     await userEvent.click(toggle);
     expect(vi.mocked(api.updateApp)).toHaveBeenCalledWith("42", { stop_with_iracing: false });
+  });
+
+  it("should show global prevent-auto-stop as checked when backend auto-stop is disabled", async () => {
+    vi.mocked(api.getAutoStop).mockResolvedValue(false);
+    render(<AppsScreen />);
+    const toggle = await screen.findByRole("switch", { name: /do not stop apps/i });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("should invert global prevent-auto-stop before saving to backend", async () => {
+    vi.mocked(api.getAutoStop).mockResolvedValue(false);
+    render(<AppsScreen />);
+    const toggle = await screen.findByRole("switch", { name: /do not stop apps/i });
+    await userEvent.click(toggle);
+    expect(vi.mocked(api.setAutoStop)).toHaveBeenCalledWith(true);
   });
 
   it("should call forceKillApp when stop is clicked", async () => {

--- a/src/components/AppFormModal.tsx
+++ b/src/components/AppFormModal.tsx
@@ -113,7 +113,7 @@ function CheckRow({
         className={cn(
           "mt-0.5 w-4 h-4 rounded border shrink-0 flex items-center justify-center transition-colors",
           checked
-            ? "bg-accent/20 border-accent"
+            ? "bg-accent-solid border-accent-solid"
             : "bg-elevated border-border-strong group-hover:border-accent/50",
         )}
       >
@@ -124,7 +124,7 @@ function CheckRow({
           className="sr-only"
         />
         {checked && (
-          <svg className="w-3 h-3 text-accent" viewBox="0 0 12 12" fill="none">
+          <svg className="w-3 h-3 text-on-accent" viewBox="0 0 12 12" fill="none">
             <path d="M2 6l2.5 2.5L10 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
         )}
@@ -303,7 +303,7 @@ export function AppFormModal({ mode, initial, onClose, onSubmit }: AppFormModalP
                 type="button"
                 onClick={onClose}
                 disabled={saving || saved}
-                className="text-xs px-3 py-1.5 rounded-md border border-border-strong text-text-muted hover:text-text transition-colors disabled:opacity-50"
+                className="text-sm px-3 py-1.5 rounded-md border border-border-strong text-text-muted hover:text-text transition-colors disabled:opacity-50"
               >
                 {t("apps.form.cancel")}
               </button>
@@ -311,10 +311,10 @@ export function AppFormModal({ mode, initial, onClose, onSubmit }: AppFormModalP
                 type="submit"
                 disabled={saving || saved || !form.name.trim() || !form.exe_path.trim()}
                 className={cn(
-                  "flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-md border transition-colors disabled:opacity-50",
+                  "flex items-center gap-1.5 text-sm font-semibold px-3 py-1.5 rounded-md border transition-colors disabled:opacity-50",
                   saved
-                    ? "bg-success/15 text-success border-success/30"
-                    : "bg-accent/15 hover:bg-accent/25 text-accent border-accent/30",
+                    ? "bg-success-solid text-on-success border-success-solid"
+                    : "bg-accent-solid hover:bg-accent-solid-hover text-on-accent border-accent-solid",
                 )}
               >
                 {saved ? (

--- a/src/components/AppFormModal.tsx
+++ b/src/components/AppFormModal.tsx
@@ -46,7 +46,7 @@ function initForm(initial?: ManagedApp): FormState {
 function SectionDivider({ title }: { title: string }) {
   return (
     <div className="flex items-center gap-2 pt-1">
-      <span className="text-[10px] font-semibold uppercase tracking-widest text-text-disabled">
+      <span className="text-xs font-semibold uppercase tracking-widest text-text-muted">
         {title}
       </span>
       <div className="flex-1 h-px bg-border" />
@@ -59,7 +59,7 @@ function Field({ label, hint, id, children }: { label: string; hint?: string; id
     <div className="flex flex-col gap-1">
       <label htmlFor={id} className="text-xs text-text-muted">{label}</label>
       {children}
-      {hint && <p className="text-xs text-text-disabled">{hint}</p>}
+      {hint && <p className="text-xs text-text-muted">{hint}</p>}
     </div>
   );
 }
@@ -131,7 +131,7 @@ function CheckRow({
       </div>
       <div>
         <p className="text-sm text-text leading-tight">{label}</p>
-        {hint && <p className="text-xs text-text-disabled mt-0.5">{hint}</p>}
+        {hint && <p className="text-xs text-text-muted mt-0.5">{hint}</p>}
       </div>
     </label>
   );
@@ -264,7 +264,7 @@ export function AppFormModal({ mode, initial, onClose, onSubmit }: AppFormModalP
             <button
               type="button"
               onClick={() => setAdvancedOpen((o) => !o)}
-              className="flex items-center gap-1.5 text-xs text-text-disabled hover:text-text-muted transition-colors self-start"
+              className="flex items-center gap-1.5 text-xs text-text-muted hover:text-text transition-colors self-start"
             >
               <ChevronDown className={cn("w-3.5 h-3.5 transition-transform", advancedOpen && "rotate-180")} />
               {t("apps.form.section_advanced")}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -42,13 +42,13 @@ export function ConfirmDialog({
         <div className="flex justify-end gap-2">
           <button
             onClick={onCancel}
-            className="text-xs px-3 py-1.5 rounded-md border border-border-strong text-text-muted hover:text-text transition-colors"
+            className="text-sm px-3 py-1.5 rounded-md border border-border-strong text-text-muted hover:text-text transition-colors"
           >
             {t("common.cancel")}
           </button>
           <button
             onClick={onConfirm}
-            className="text-xs font-semibold px-3 py-1.5 rounded-md bg-danger/15 hover:bg-danger/25 text-danger border border-danger/30 transition-colors"
+            className="text-sm font-semibold px-3 py-1.5 rounded-md bg-danger-solid text-on-danger border border-danger-solid hover:bg-danger-solid-hover transition-colors"
           >
             {confirmLabel}
           </button>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -29,7 +29,7 @@ export function Sidebar({ active, onChange }: SidebarProps) {
           className={cn(
             "flex items-center gap-2.5 px-3 py-2 rounded text-sm font-medium transition-colors text-left w-full border",
             active === id
-              ? "bg-accent/10 text-text border-accent/20"
+              ? "bg-elevated text-text border-accent"
               : "text-text-muted hover:text-text hover:bg-surface border-transparent",
           )}
         >

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -41,7 +41,7 @@ export function StatusBar({ iRacingRunning, sessionType, managedCount, paused }:
             "flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium transition-colors",
             iRacingRunning
               ? "bg-accent/10 border border-accent/25 text-accent"
-              : "bg-surface border border-border text-text-muted",
+              : "bg-surface border border-border-strong text-text-muted",
           )}
         >
           <Circle className={cn(

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
 import { LanguageSelector } from "@/components/LanguageSelector";
 import { PitlaneLogo } from "@/components/PitlaneLogo";
+import { ThemeSelector } from "@/components/ThemeSelector";
 
 interface StatusBarProps {
   iRacingRunning: boolean;
@@ -53,6 +54,7 @@ export function StatusBar({ iRacingRunning, sessionType, managedCount, paused }:
 
         <div className="w-px h-4 bg-border" />
 
+        <ThemeSelector variant="compact" />
         <LanguageSelector variant="compact" />
       </div>
     </header>

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,0 +1,76 @@
+import { Check, ChevronDown, Palette } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { THEMES, getTheme, setTheme, type Theme } from "@/theme";
+import { cn } from "@/lib/cn";
+
+interface ThemeSelectorProps {
+  variant?: "default" | "compact";
+}
+
+const SHORT: Record<Theme, string> = {
+  "pitlane-aurora": "Aurora",
+  "pitlane-nebula": "Nebula",
+};
+
+export function ThemeSelector({ variant = "default" }: ThemeSelectorProps) {
+  const { t } = useTranslation();
+  const [current, setCurrent] = useState<Theme>(() => getTheme());
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleThemeChange(e: Event) {
+      setCurrent((e as CustomEvent<Theme>).detail);
+    }
+
+    window.addEventListener("pitlane:theme-change", handleThemeChange);
+    return () => window.removeEventListener("pitlane:theme-change", handleThemeChange);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1 text-text-muted hover:text-text-secondary transition-colors"
+      >
+        <Palette className={cn("shrink-0", variant === "compact" ? "w-3 h-3" : "w-3.5 h-3.5")} />
+        <span className="text-xs">
+          {variant === "compact" ? SHORT[current] : t(`settings.themes.${current}`)}
+        </span>
+        <ChevronDown className={cn("w-3 h-3 transition-transform", open && "rotate-180")} />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full mt-1.5 z-50 bg-elevated border border-border-strong rounded-lg shadow-xl min-w-[168px] py-1 overflow-hidden">
+          {THEMES.map((theme) => (
+            <button
+              key={theme}
+              type="button"
+              onClick={() => { setTheme(theme); setOpen(false); }}
+              className={cn(
+                "w-full flex items-center justify-between gap-3 px-3 py-1.5 text-xs text-left transition-colors",
+                theme === current
+                  ? "text-accent bg-accent/10"
+                  : "text-text-muted hover:text-text hover:bg-surface",
+              )}
+            >
+              {t(`settings.themes.${theme}`)}
+              {theme === current && <Check className="w-3 h-3 shrink-0" />}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/screens/AppsScreen.tsx
+++ b/src/components/screens/AppsScreen.tsx
@@ -113,7 +113,7 @@ function AppCard({ app, status, onStart, onStop, onEdit, onDelete, onToggleEnabl
             <StatusIndicator status={status} />
             <span className="text-sm font-medium text-text truncate">{app.name}</span>
           </div>
-          <p className="text-xs text-text-disabled truncate font-mono mt-0.5" title={statusLabel(status, t)}>
+          <p className="text-xs text-text-muted truncate font-mono mt-0.5" title={statusLabel(status, t)}>
             {statusLabel(status, t)}
           </p>
         </div>
@@ -123,7 +123,7 @@ function AppCard({ app, status, onStart, onStop, onEdit, onDelete, onToggleEnabl
             <button
               title={t("apps.stop")}
               onClick={onStop}
-              className="flex items-center gap-1 text-xs px-2 py-1 rounded text-warning/80 hover:text-warning hover:bg-warning/10 transition-colors border border-transparent hover:border-warning/20"
+              className="flex items-center gap-1 text-xs px-2 py-1 rounded text-danger/80 hover:text-danger hover:bg-danger/10 transition-colors border border-transparent hover:border-danger/20"
             >
               <Square className="w-3 h-3" />
               {t("apps.stop")}
@@ -132,7 +132,7 @@ function AppCard({ app, status, onStart, onStop, onEdit, onDelete, onToggleEnabl
             <button
               title={t("apps.start")}
               onClick={onStart}
-              className="flex items-center gap-1 text-xs px-2 py-1 rounded text-text-muted hover:text-text hover:bg-elevated transition-colors border border-transparent hover:border-border-strong"
+              className="flex items-center gap-1 text-xs px-2 py-1 rounded text-success/80 hover:text-success hover:bg-success/10 transition-colors border border-transparent hover:border-success/20"
             >
               <Play className="w-3 h-3" />
               {t("apps.start")}

--- a/src/components/screens/AppsScreen.tsx
+++ b/src/components/screens/AppsScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { AlertTriangle, Circle, LayoutList, Pencil, Plus, Square, Play, Trash2 } from "lucide-react";
+import { Activity, AlertTriangle, Ban, Clock3, LayoutList, Pencil, Plus, Square, Play, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { cn } from "@/lib/cn";
@@ -10,32 +10,46 @@ import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 // ── Status helpers ────────────────────────────────────────────────────────────
 
-function StatusIndicator({ status }: { status: AppStatus | undefined }) {
+function StatusBadge({ status, enabled, t }: { status: AppStatus | undefined; enabled: boolean; t: TFunction }) {
   const type = status?.state.type ?? "idle";
+
+  if (!enabled) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded border border-border-strong bg-elevated px-1.5 py-0.5 text-[11px] font-medium text-text-muted">
+        <Ban className="h-3.5 w-3.5 shrink-0 stroke-[2.5]" />
+        {t("apps.status.disabled")}
+      </span>
+    );
+  }
 
   if (type === "running") {
     return (
-      <Circle className="w-2 h-2 fill-success text-success shrink-0" aria-label="Running" />
+      <span className="inline-flex items-center gap-1.5 rounded border border-success bg-elevated px-1.5 py-0.5 text-[11px] font-medium text-success">
+        <Activity className="h-3.5 w-3.5 shrink-0 stroke-[2.5]" />
+        {t("apps.status.running")}
+      </span>
     );
   }
   if (type === "crashed") {
     return (
-      <AlertTriangle className="w-3 h-3 text-warning shrink-0" aria-label="Crashed" />
+      <span className="inline-flex items-center gap-1 rounded border border-warning bg-elevated px-1.5 py-0.5 text-[11px] font-medium text-warning">
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0 stroke-[2.5]" />
+        {t("apps.status.crashed")}
+      </span>
     );
   }
   return (
-    <Circle className="w-2 h-2 text-text-disabled shrink-0" aria-label="Idle" />
+    <span className="inline-flex items-center gap-1.5 rounded border border-border-strong bg-elevated px-1.5 py-0.5 text-[11px] font-medium text-text-secondary">
+      <Clock3 className="h-3.5 w-3.5 shrink-0 stroke-[2.5]" />
+      {t("apps.status.idle")}
+    </span>
   );
 }
 
-function statusLabel(status: AppStatus | undefined, t: TFunction): string {
-  const type = status?.state.type ?? "idle";
-  if (type === "running") {
-    const pid = (status!.state as { pid: number }).pid;
-    return `${t("apps.status.running")} · PID ${pid}`;
-  }
-  if (type === "crashed") return t("apps.status.crashed");
-  return t("apps.status.idle");
+function statusDetail(status: AppStatus | undefined): string | null {
+  if (status?.state.type !== "running") return null;
+  const pid = (status.state as { pid: number }).pid;
+  return `PID ${pid}`;
 }
 
 // ── App letter-avatar ─────────────────────────────────────────────────────────
@@ -58,22 +72,43 @@ function AppAvatar({ name }: { name: string }) {
 
 // ── Toggle switch ─────────────────────────────────────────────────────────────
 
-function Toggle({ checked, onChange, label }: { checked: boolean; onChange: (v: boolean) => void; label: string }) {
+function Toggle({
+  checked,
+  disabled = false,
+  onChange,
+  label,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+}) {
   return (
     <button
       type="button"
       role="switch"
       aria-checked={checked}
       aria-label={label}
-      onClick={() => onChange(!checked)}
+      disabled={disabled}
+      onClick={() => {
+        if (!disabled) onChange(!checked);
+      }}
       className={cn(
-        "relative w-8 h-4 rounded-full transition-colors shrink-0",
-        checked ? "bg-accent/40" : "bg-elevated border border-border-strong",
+        "flex h-5 w-9 items-center rounded-full p-0.5 transition-colors shrink-0 disabled:cursor-not-allowed",
+        disabled
+          ? "bg-elevated border border-border"
+          : checked
+            ? "bg-accent-solid hover:bg-accent-solid-hover"
+            : "bg-elevated border border-accent-solid hover:bg-surface",
       )}
     >
       <span className={cn(
-        "absolute top-0.5 w-3 h-3 rounded-full transition-all",
-        checked ? "left-[18px] bg-accent" : "left-0.5 bg-text-disabled",
+        "h-4 w-4 rounded-full transition-transform",
+        disabled
+          ? "translate-x-0 bg-text-disabled"
+          : checked
+            ? "translate-x-4 bg-on-accent"
+            : "translate-x-0 bg-accent-solid",
       )} />
     </button>
   );
@@ -95,27 +130,37 @@ interface AppCardProps {
 function AppCard({ app, status, onStart, onStop, onEdit, onDelete, onToggleEnabled, onToggleStopWithIracing }: AppCardProps) {
   const { t } = useTranslation();
   const running = status?.state.type === "running";
+  const detail = statusDetail(status);
+  const appDisabled = !app.enabled;
 
   return (
     <li
       data-testid="app-card"
       className={cn(
-        "flex flex-col rounded-lg border bg-surface border-border-strong transition-opacity",
-        !app.enabled && "opacity-50",
+        "flex flex-col rounded-lg border bg-surface border-border-strong transition-colors",
+        !app.enabled && "bg-surface-disabled border-border",
       )}
     >
       {/* Row 1: icon / name / status / actions */}
       <div className="flex items-center gap-3 px-3 py-2.5">
-        <AppAvatar name={app.name} />
+        <div className={cn(appDisabled && "opacity-55")}>
+          <AppAvatar name={app.name} />
+        </div>
 
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5">
-            <StatusIndicator status={status} />
-            <span className="text-sm font-medium text-text truncate">{app.name}</span>
+          <div className="flex flex-col gap-1">
+            <span className={cn("text-sm font-medium text-text truncate", appDisabled && "opacity-60")}>
+              {app.name}
+            </span>
+            <div className="flex items-center gap-2 min-h-5">
+              <StatusBadge status={status} enabled={app.enabled} t={t} />
+              {detail && (
+                <span className="text-xs text-text-muted truncate font-mono" title={detail}>
+                  {detail}
+                </span>
+              )}
+            </div>
           </div>
-          <p className="text-xs text-text-muted truncate font-mono mt-0.5" title={statusLabel(status, t)}>
-            {statusLabel(status, t)}
-          </p>
         </div>
 
         <div className="flex items-center gap-1 shrink-0">
@@ -123,18 +168,18 @@ function AppCard({ app, status, onStart, onStop, onEdit, onDelete, onToggleEnabl
             <button
               title={t("apps.stop")}
               onClick={onStop}
-              className="flex items-center gap-1 text-xs px-2 py-1 rounded text-danger/80 hover:text-danger hover:bg-danger/10 transition-colors border border-transparent hover:border-danger/20"
+              className="flex items-center gap-1 text-sm font-semibold px-2.5 py-1.5 rounded-md bg-danger-solid text-on-danger border border-danger-solid hover:bg-danger-solid-hover transition-colors"
             >
-              <Square className="w-3 h-3" />
+              <Square className="w-3.5 h-3.5 fill-current stroke-[2.5]" />
               {t("apps.stop")}
             </button>
           ) : (
             <button
               title={t("apps.start")}
               onClick={onStart}
-              className="flex items-center gap-1 text-xs px-2 py-1 rounded text-success/80 hover:text-success hover:bg-success/10 transition-colors border border-transparent hover:border-success/20"
+              className="flex items-center gap-1 text-sm font-semibold px-2.5 py-1.5 rounded-md bg-success-solid text-on-success border border-success-solid hover:bg-success-solid-hover transition-colors"
             >
-              <Play className="w-3 h-3" />
+              <Play className="w-3.5 h-3.5 fill-current stroke-[2.5]" />
               {t("apps.start")}
             </button>
           )}
@@ -142,17 +187,17 @@ function AppCard({ app, status, onStart, onStop, onEdit, onDelete, onToggleEnabl
           <button
             title={t("apps.edit")}
             onClick={onEdit}
-            className="p-1.5 rounded text-text-muted hover:text-text hover:bg-elevated transition-colors"
+            className="p-1.5 rounded text-text-secondary hover:text-text hover:bg-elevated transition-colors"
           >
-            <Pencil className="w-3.5 h-3.5" />
+            <Pencil className="w-4 h-4 stroke-[2.5]" />
           </button>
 
           <button
             title={t("apps.delete")}
             onClick={onDelete}
-            className="p-1.5 rounded text-text-muted hover:text-danger hover:bg-danger/10 transition-colors"
+            className="p-1.5 rounded text-danger hover:bg-danger/10 transition-colors"
           >
-            <Trash2 className="w-3.5 h-3.5" />
+            <Trash2 className="w-4 h-4 stroke-[2.5]" />
           </button>
         </div>
       </div>
@@ -160,17 +205,18 @@ function AppCard({ app, status, onStart, onStop, onEdit, onDelete, onToggleEnabl
       {/* Row 2: auto-start / auto-stop toggles */}
       <div className="flex items-center justify-between px-3 pb-2.5 -mt-0.5 gap-4">
         <div className="flex items-center gap-2">
-          <span className="text-xs text-text-muted">{t("apps.auto_start")}</span>
+          <span className="text-xs text-text-secondary">{t("apps.auto_start")}</span>
           <Toggle
             checked={app.enabled}
             onChange={onToggleEnabled}
             label={t("apps.auto_start")}
           />
         </div>
-        <div className="flex items-center gap-2">
+        <div className={cn("flex items-center gap-2", appDisabled && "opacity-60")}>
           <span className="text-xs text-text-muted">{t("apps.auto_stop")}</span>
           <Toggle
             checked={app.stop_with_iracing}
+            disabled={appDisabled}
             onChange={onToggleStopWithIracing}
             label={t("apps.auto_stop")}
           />
@@ -193,7 +239,7 @@ export function AppsScreen() {
   const [activeProfile, setActiveProfile] = useState<Profile | null>(null);
   const [modal, setModal] = useState<ModalState>(null);
   const [confirmDelete, setConfirmDelete] = useState<ManagedApp | null>(null);
-  const [autoStop, setAutoStop] = useState(true);
+  const [preventAutoStop, setPreventAutoStop] = useState(false);
   const statuses = useAppStatuses();
 
   async function loadApps() {
@@ -205,15 +251,15 @@ export function AppsScreen() {
     ]);
     setApps(loadedApps);
     setActiveProfile(profiles.find((p) => p.id === activeId) ?? null);
-    setAutoStop(autoStopVal);
+    setPreventAutoStop(!autoStopVal);
   }
 
   useEffect(() => { loadApps(); }, []);
 
-  async function handleAutoStopToggle() {
-    const next = !autoStop;
-    setAutoStop(next);
-    await api.setAutoStop(next);
+  async function handlePreventAutoStopToggle() {
+    const next = !preventAutoStop;
+    setPreventAutoStop(next);
+    await api.setAutoStop(!next);
   }
 
   async function handleFormSubmit(data: NewApp) {
@@ -253,28 +299,24 @@ export function AppsScreen() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={handleAutoStopToggle}
-            title={t("apps.auto_stop_hint")}
-            className={cn(
-              "flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-md border transition-colors",
-              autoStop
-                ? "bg-accent/10 text-accent border-accent/30 hover:bg-accent/20"
-                : "bg-elevated text-text-muted border-border-strong hover:text-text",
-            )}
+          <div
+            className="flex items-center gap-2 rounded-md border border-border-strong bg-surface px-2.5 py-1.5"
           >
-            <div className={cn(
-              "w-1.5 h-1.5 rounded-full shrink-0",
-              autoStop ? "bg-accent" : "bg-text-disabled",
-            )} />
-            {t("apps.auto_stop_label")}
-          </button>
+            <span className="text-xs text-text-secondary">
+              <span className="font-bold text-accent">{t("apps.auto_stop_label_emphasis")}</span>{" "}
+              {t("apps.auto_stop_label_rest")}
+            </span>
+            <Toggle
+              checked={preventAutoStop}
+              onChange={handlePreventAutoStopToggle}
+              label={t("apps.auto_stop_label")}
+            />
+          </div>
           <button
             onClick={() => setModal({ type: "add" })}
-            className="flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-md bg-accent/15 hover:bg-accent/25 text-accent border border-accent/30 transition-colors"
+            className="flex items-center gap-1.5 text-sm font-semibold px-3 py-1.5 rounded-md bg-accent-solid text-on-accent border border-accent-solid hover:bg-accent-solid-hover transition-colors"
           >
-            <Plus className="w-3.5 h-3.5" />
+            <Plus className="w-4 h-4 stroke-[2.5]" />
             {t("apps.add")}
           </button>
         </div>
@@ -282,13 +324,13 @@ export function AppsScreen() {
 
       {/* App list */}
       {apps.length === 0 ? (
-        <div className="flex-1 flex flex-col items-center justify-center text-text-disabled gap-3">
+        <div className="flex-1 flex flex-col items-center justify-center text-text-muted gap-3">
           <LayoutList className="w-8 h-8" />
           <div className="flex flex-col items-center gap-2">
             <p className="text-sm">{t("apps.empty")}</p>
             <button
               onClick={() => setModal({ type: "add" })}
-              className="text-xs font-semibold px-3 py-1.5 rounded-md bg-accent/15 hover:bg-accent/25 text-accent border border-accent/30 transition-colors"
+              className="text-sm font-semibold px-3 py-1.5 rounded-md bg-accent-solid text-on-accent border border-accent-solid hover:bg-accent-solid-hover transition-colors"
             >
               {t("apps.add_first")}
             </button>

--- a/src/components/screens/LogScreen.tsx
+++ b/src/components/screens/LogScreen.tsx
@@ -8,14 +8,14 @@ const kindStyle: Record<LogKind, string> = {
   launch:        "text-success",
   stop:          "text-warning",
   iracing_start: "text-accent",
-  iracing_stop:  "text-accent/60",
+  iracing_stop:  "text-accent/75",
 };
 
 const kindLabel: Record<LogKind, string> = {
   launch:        "LAUNCH",
   stop:          "STOP",
-  iracing_start: "IRACING",
-  iracing_stop:  "IRACING",
+  iracing_start: "iRACING ▶",
+  iracing_stop:  "iRACING ■",
 };
 
 function formatTime(ms: number): string {
@@ -53,7 +53,7 @@ export function LogScreen() {
                 (entry.kind === "iracing_start" || entry.kind === "iracing_stop") && "bg-accent/5",
               )}
             >
-              <span className="text-text-disabled shrink-0 w-16">{formatTime(entry.timestamp_ms)}</span>
+              <span className="text-text-muted shrink-0 w-16">{formatTime(entry.timestamp_ms)}</span>
               <span className={cn("shrink-0 w-14 font-semibold", kindStyle[entry.kind])}>
                 {kindLabel[entry.kind]}
               </span>

--- a/src/components/screens/SettingsScreen.tsx
+++ b/src/components/screens/SettingsScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/cn";
 import { LanguageSelector } from "@/components/LanguageSelector";
 import { api, type Settings, type TriggerMode } from "@/lib/api";
 
@@ -75,7 +76,7 @@ export function SettingsScreen() {
               </button>
             ))}
           </div>
-          <p className="text-xs text-text-disabled">{t("settings.trigger_hint")}</p>
+          <p className="text-xs text-text-muted">{t("settings.trigger_hint")}</p>
         </div>
       </section>
 
@@ -133,16 +134,22 @@ function ToggleRow({
     <div className="flex items-center justify-between">
       <div>
         <p className="text-xs font-medium text-text-secondary">{label}</p>
-        <p className="text-xs text-text-disabled">{description}</p>
+        <p className="text-xs text-text-muted">{description}</p>
       </div>
       <button
         role="switch"
         aria-checked={enabled}
         onClick={() => onChange(!enabled)}
-        className={`relative w-10 h-5 rounded-full transition-colors overflow-hidden ${enabled ? "bg-accent/60" : "bg-zinc-600"}`}
+        className={cn(
+          "relative w-10 h-5 rounded-full transition-colors shrink-0",
+          enabled ? "bg-accent/40" : "bg-elevated border border-border-strong",
+        )}
       >
         <span
-          className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${enabled ? "translate-x-5" : "translate-x-0"}`}
+          className={cn(
+            "absolute top-0.5 w-4 h-4 rounded-full transition-all",
+            enabled ? "left-[22px] bg-accent" : "left-0.5 bg-text-disabled",
+          )}
         />
       </button>
     </div>

--- a/src/components/screens/SettingsScreen.tsx
+++ b/src/components/screens/SettingsScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
 import { LanguageSelector } from "@/components/LanguageSelector";
+import { ThemeSelector } from "@/components/ThemeSelector";
 import { api, type Settings, type TriggerMode } from "@/lib/api";
 
 const DEFAULT_SETTINGS: Settings = {
@@ -66,8 +67,8 @@ export function SettingsScreen() {
               <button
                 key={mode}
                 onClick={() => patch("default_trigger", mode)}
-                className="px-3 py-1.5 text-xs rounded border transition-colors
-                           data-[active=true]:bg-accent/15 data-[active=true]:border-accent/40 data-[active=true]:text-accent
+                className="px-3 py-1.5 text-sm rounded border transition-colors
+                           data-[active=true]:bg-accent-solid data-[active=true]:border-accent-solid data-[active=true]:text-on-accent
                            data-[active=false]:border-border-strong data-[active=false]:text-text-muted
                            data-[active=false]:hover:border-elevated data-[active=false]:hover:text-text-secondary"
                 data-active={settings.default_trigger === mode}
@@ -104,13 +105,20 @@ export function SettingsScreen() {
           </div>
           <LanguageSelector variant="default" />
         </div>
+
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs font-medium text-text-secondary">{t("settings.theme_label")}</p>
+          </div>
+          <ThemeSelector variant="default" />
+        </div>
       </section>
 
       <div className="flex justify-end pt-2">
         <button
           onClick={handleSave}
           disabled={saving}
-          className="px-4 py-1.5 text-xs font-semibold rounded bg-accent/15 hover:bg-accent/25 text-accent border border-accent/30 transition-colors disabled:opacity-50"
+          className="px-4 py-1.5 text-sm font-semibold rounded bg-accent-solid hover:bg-accent-solid-hover text-on-accent border border-accent-solid transition-colors disabled:opacity-50"
         >
           {saving ? "…" : t("settings.save")}
         </button>
@@ -141,14 +149,14 @@ function ToggleRow({
         aria-checked={enabled}
         onClick={() => onChange(!enabled)}
         className={cn(
-          "relative w-10 h-5 rounded-full transition-colors shrink-0",
-          enabled ? "bg-accent/40" : "bg-elevated border border-border-strong",
+          "flex h-5 w-10 items-center rounded-full p-0.5 transition-colors shrink-0",
+          enabled ? "bg-accent-solid hover:bg-accent-solid-hover" : "bg-elevated border border-accent-solid hover:bg-surface",
         )}
       >
         <span
           className={cn(
-            "absolute top-0.5 w-4 h-4 rounded-full transition-all",
-            enabled ? "left-[22px] bg-accent" : "left-0.5 bg-text-disabled",
+            "h-4 w-4 rounded-full transition-transform",
+            enabled ? "translate-x-5 bg-on-accent" : "translate-x-0 bg-accent-solid",
           )}
         />
       </button>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -28,12 +28,15 @@
     "delete_confirm": "Delete",
     "auto_start": "Auto-start with iRacing",
     "auto_stop": "Stop with iRacing",
-    "auto_stop_label": "Stop on close",
-    "auto_stop_hint": "Stop all apps when iRacing closes",
+    "auto_stop_label": "Do not stop apps when iRacing closes",
+    "auto_stop_label_emphasis": "DO NOT",
+    "auto_stop_label_rest": "stop apps when iRacing closes",
+    "auto_stop_hint": "Disables global auto-stop when iRacing closes",
     "status": {
       "running": "Running",
       "idle": "Idle",
-      "crashed": "Crashed"
+      "crashed": "Crashed",
+      "disabled": "Disabled"
     },
     "form": {
       "title_add": "Add app",
@@ -103,9 +106,14 @@
     "notifications_label": "Notifications",
     "notifications_hint": "Toast on session start",
     "language_label": "Language",
+    "theme_label": "Theme",
     "languages": {
       "pt-BR": "Português (BR)",
       "en": "English"
+    },
+    "themes": {
+      "pitlane-aurora": "Pitlane Aurora",
+      "pitlane-nebula": "Pitlane Nebula"
     }
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -28,12 +28,15 @@
     "delete_confirm": "Excluir",
     "auto_start": "Iniciar com iRacing",
     "auto_stop": "Parar com iRacing",
-    "auto_stop_label": "Parar ao fechar",
-    "auto_stop_hint": "Parar todos os apps quando o iRacing fechar",
+    "auto_stop_label": "Não parar apps ao fechar iRacing",
+    "auto_stop_label_emphasis": "NÃO",
+    "auto_stop_label_rest": "parar apps ao fechar iRacing",
+    "auto_stop_hint": "Desativa a parada automática global ao fechar o iRacing",
     "status": {
       "running": "Rodando",
       "idle": "Inativo",
-      "crashed": "Travado"
+      "crashed": "Travado",
+      "disabled": "Desabilitado"
     },
     "form": {
       "title_add": "Adicionar app",
@@ -103,9 +106,14 @@
     "notifications_label": "Notificações",
     "notifications_hint": "Toast ao iniciar sessão",
     "language_label": "Idioma",
+    "theme_label": "Tema",
     "languages": {
       "pt-BR": "Português (BR)",
       "en": "English"
+    },
+    "themes": {
+      "pitlane-aurora": "Pitlane Aurora",
+      "pitlane-nebula": "Pitlane Nebula"
     }
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,7 @@
 
   /* --- Bordas --- */
   --color-border:        #2a1850;
-  --color-border-strong: #3d2d6a;
+  --color-border-strong: #8272b9; /* bumped from #3d2d6a — 3.2:1 on elevated, 4.4:1 on base */
 
   /* --- Texto (todos >= 4.5:1 sobre base e surface) --- */
   --color-text:           #f0eeff; /* 15.8:1 on base */

--- a/src/index.css
+++ b/src/index.css
@@ -1,30 +1,130 @@
 @import "tailwindcss";
 
 @theme {
-  /* --- Superfícies --- */
-  --color-canvas:   #0a0618; /* roxo quase preto — header, overlay */
-  --color-base:     #1a0f36; /* fundo principal — roxo escuro */
-  --color-surface:  #251848; /* cards, painéis */
-  --color-elevated: #352460; /* hover, itens elevados */
+  /* --- Primitive ramps: Pitlane Aurora --- */
+  --color-purple-100:  #f4f0ff;
+  --color-purple-200:  #d1c5f2;
+  --color-purple-300:  #a999d3;
+  --color-purple-400:  #7c6dab;
+  --color-purple-500:  #6f618f;
+  --color-purple-600:  #33264f;
+  --color-purple-700:  #251a43;
+  --color-purple-800:  #1b1233;
+  --color-purple-900:  #120b24;
+  --color-purple-1000: #090714;
 
-  /* --- Bordas --- */
-  --color-border:        #2a1850;
-  --color-border-strong: #8272b9; /* bumped from #3d2d6a — 3.2:1 on elevated, 4.4:1 on base */
+  --color-aqua-100:  #d8fffb;
+  --color-aqua-300:  #7ae7e0;
+  --color-aqua-400:  #4dd9d0;
+  --color-aqua-500:  #36beb7;
+  --color-aqua-600:  #208984;
+  --color-aqua-1000: #020707;
 
-  /* --- Texto (todos >= 4.5:1 sobre base e surface) --- */
-  --color-text:           #f0eeff; /* 15.8:1 on base */
-  --color-text-secondary: #c4b8e0; /* lavanda */
-  --color-text-muted:     #9d8cc0; /* 6.0:1 on base, 5.3:1 on surface */
-  --color-text-disabled:  #5a4880;
+  --color-green-300:  #7be9b4;
+  --color-green-400:  #47d18c;
+  --color-green-500:  #35b875;
+  --color-green-600:  #279b63;
+  --color-green-1000: #06130c;
 
-  /* --- Accent teal-aqua (usar texto escuro sobre ele) --- */
-  --color-accent:       #6ec4c0;
-  --color-accent-hover: #58b0ac;
+  --color-amber-300:  #ffe082;
+  --color-amber-400:  #f2c94c;
+  --color-amber-1000: #171104;
 
-  /* --- Status / Feedback --- */
-  --color-success: #34d399;
-  --color-warning: #fbbf24;
-  --color-danger:  #f87171;
+  --color-red-300:  #ff9a9a;
+  --color-red-400:  #ff7373;
+  --color-red-500:  #e0646b;
+  --color-red-600:  #cf5259;
+  --color-red-1000: #180607;
+
+  /* --- Semantic tokens --- */
+  --color-canvas:   var(--color-purple-1000);
+  --color-base:     var(--color-purple-900);
+  --color-surface:  var(--color-purple-800);
+  --color-surface-disabled: var(--color-purple-900);
+  --color-elevated: var(--color-purple-700);
+
+  --color-border:        var(--color-purple-600);
+  --color-border-strong: var(--color-purple-400);
+
+  --color-text:           var(--color-purple-100);
+  --color-text-secondary: var(--color-purple-200);
+  --color-text-muted:     var(--color-purple-300);
+  --color-text-disabled:  var(--color-purple-500);
+
+  --color-accent:             var(--color-aqua-400);
+  --color-accent-hover:       var(--color-aqua-300);
+  --color-accent-solid:       var(--color-aqua-500);
+  --color-accent-solid-hover: var(--color-aqua-600);
+  --color-on-accent:          var(--color-aqua-1000);
+
+  --color-success:             var(--color-green-400);
+  --color-success-solid:       var(--color-green-500);
+  --color-success-solid-hover: var(--color-green-600);
+  --color-warning:             var(--color-amber-400);
+  --color-danger:              var(--color-red-400);
+  --color-danger-solid:        var(--color-red-500);
+  --color-danger-solid-hover:  var(--color-red-600);
+  --color-on-success:          var(--color-green-1000);
+  --color-on-warning:          var(--color-amber-1000);
+  --color-on-danger:           var(--color-red-1000);
+}
+
+html[data-theme="pitlane-nebula"] {
+  /* --- Primitive ramps: Pitlane Nebula --- */
+  --color-aqua-100:  #eefdfb;
+  --color-aqua-200:  #c4e7e3;
+  --color-aqua-300:  #93c7c1;
+  --color-aqua-400:  #6aa09b;
+  --color-aqua-500:  #4a7773;
+  --color-aqua-600:  #235c5a;
+  --color-aqua-700:  #174343;
+  --color-aqua-800:  #103030;
+  --color-aqua-900:  #0b2020;
+  --color-aqua-1000: #061313;
+
+  --color-purple-100:  #f1edff;
+  --color-purple-200:  #d8ccff;
+  --color-purple-300:  #b8a2ff;
+  --color-purple-400:  #9c82f2;
+  --color-purple-500:  #8168d8;
+  --color-purple-600:  #6b55bd;
+  --color-purple-700:  #45347f;
+  --color-purple-800:  #30245c;
+  --color-purple-900:  #1c1438;
+  --color-purple-1000: #0d0718;
+
+  --color-green-300:  #7be9b4;
+  --color-green-400:  #55d99a;
+  --color-green-500:  #35b875;
+  --color-green-600:  #279b63;
+
+  --color-amber-300:  #ffe082;
+  --color-amber-400:  #f2c94c;
+
+  --color-red-300:  #ff9a9a;
+  --color-red-400:  #ff8585;
+  --color-red-500:  #e0646b;
+  --color-red-600:  #cf5259;
+
+  --color-canvas:   var(--color-aqua-1000);
+  --color-base:     var(--color-aqua-900);
+  --color-surface:  var(--color-aqua-800);
+  --color-surface-disabled: var(--color-aqua-900);
+  --color-elevated: var(--color-aqua-700);
+
+  --color-border:        var(--color-aqua-600);
+  --color-border-strong: var(--color-aqua-400);
+
+  --color-text:           var(--color-aqua-100);
+  --color-text-secondary: var(--color-aqua-200);
+  --color-text-muted:     var(--color-aqua-300);
+  --color-text-disabled:  var(--color-aqua-500);
+
+  --color-accent:             var(--color-purple-300);
+  --color-accent-hover:       var(--color-purple-200);
+  --color-accent-solid:       var(--color-purple-400);
+  --color-accent-solid-hover: var(--color-purple-500);
+  --color-on-accent:          var(--color-purple-1000);
 }
 
 @layer base {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
 import "./i18n";
+import "./theme";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,26 @@
+export const THEMES = ["pitlane-aurora", "pitlane-nebula"] as const;
+export type Theme = (typeof THEMES)[number];
+
+const STORAGE_KEY = "pitlane_theme";
+const DEFAULT_THEME: Theme = "pitlane-aurora";
+
+function isTheme(value: string | null): value is Theme {
+  return THEMES.includes(value as Theme);
+}
+
+export function getTheme(): Theme {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  return isTheme(saved) ? saved : DEFAULT_THEME;
+}
+
+export function applyTheme(theme: Theme) {
+  document.documentElement.dataset.theme = theme;
+}
+
+export function setTheme(theme: Theme) {
+  localStorage.setItem(STORAGE_KEY, theme);
+  applyTheme(theme);
+  window.dispatchEvent(new CustomEvent<Theme>("pitlane:theme-change", { detail: theme }));
+}
+
+applyTheme(getTheme());

--- a/tmp/interface-redesign-proposal.md
+++ b/tmp/interface-redesign-proposal.md
@@ -1,0 +1,260 @@
+# Pitlane - Proposta de Reformulacao Da Interface
+
+Data: 2026-04-30
+
+Escopo: proposta de produto e UX. Nenhuma implementacao foi feita.
+
+## Objetivo
+
+Transformar o Pitlane em uma interface mais operacional e previsivel para gerenciamento de apps associados ao iRacing. A tela principal deve funcionar como um painel de controle: status primeiro, lista de apps em seguida, configuracao detalhada apenas quando necessaria.
+
+## Problemas Atuais
+
+- Acoes principais e estados usam estilos parecidos, entao "Start", "Add", "iRacing online" e selecao visual competem pela mesma cor.
+- Cards de apps sao compactos, mas misturam identidade, status, acoes e toggles no mesmo peso visual.
+- O modal de app e longo e tecnico; campos avancados aparecem dentro do mesmo fluxo de cadastro basico.
+- Settings e Apps usam padroes parecidos, mas nao exatamente iguais para toggles, botoes e agrupamentos.
+- Log e History parecem telas secundarias cruas, sem filtros, resumo ou leitura por severidade/evento.
+- Acessibilidade esta sendo tratada como troca de classes, quando deveria entrar nos padroes de componente.
+
+## Arquitetura Recomendada
+
+Manter as quatro secoes, mas mudar a hierarquia:
+
+1. Apps: painel operacional principal.
+2. Sessions: substituir ou evoluir History para historico de sessoes com resumo.
+3. Activity: evoluir Log para feed filtravel.
+4. Settings: configuracoes globais, mais enxutas.
+
+Se quiser manter os nomes atuais por enquanto, a mesma estrutura pode ser aplicada sem mudar rotas.
+
+## Layout Principal
+
+### Shell
+
+- Header fixo com logo, status do iRacing, apps gerenciados ativos e seletor de idioma.
+- Sidebar com largura um pouco menor ou modo icon+label, usando `aria-current`.
+- Conteudo principal com header de tela padronizado: titulo, descricao curta e acoes.
+- Evitar cards dentro de cards. Usar lista densa para apps e paineis apenas para agrupamentos reais.
+
+### Header Operacional
+
+No topo da tela Apps, adicionar uma faixa compacta com:
+
+- estado iRacing: Offline, Open, Racing;
+- apps rodando: contador;
+- auto-stop global: switch com texto explicito;
+- perfil ativo: seletor ou link de configuracao.
+
+Isso tira informacao critica dos cards individuais e reduz repeticao.
+
+## Tela Apps
+
+### Lista Recomendada
+
+Cada app deve ser uma linha/card operacional com tres zonas:
+
+| Zona | Conteudo | Observacao |
+|---|---|---|
+| Identidade | avatar pequeno, nome, caminho/processo truncado | texto principal sempre legivel |
+| Estado | Running/Idle/Crashed/Disabled, PID quando existir | usar icone + label, nao so cor |
+| Acoes | Start/Stop, Edit, Delete, toggles | botoes com area clicavel 44x44 |
+
+### Estados De Card
+
+- Running: rail lateral ou badge `success`, botao principal vira Stop.
+- Idle: neutro, botao principal Start.
+- Crashed: badge `warning`, acao secundaria "Restart" pode aparecer no futuro.
+- Disabled: nao reduzir opacidade do card inteiro; mostrar badge "Disabled" e reduzir apenas controles indisponiveis.
+
+### Acoes
+
+- `Add app`: botao primario preenchido.
+- `Start`: botao secundario semantico success, nao precisa ser preenchido.
+- `Stop`: botao danger, com icone Square.
+- `Edit/Delete`: icon buttons com tooltip e `aria-label`.
+- Auto-start e Auto-stop por app: switches alinhados e com labels proximos.
+
+## Modal Add/Edit App
+
+Transformar o modal em formulario por secoes, mas com densidade controlada:
+
+1. Basic
+   - Name
+   - Executable path
+   - Enabled
+   - Stop with iRacing
+
+2. Launch
+   - Startup delay
+   - Arguments
+   - Working directory
+
+3. Recovery
+   - Restart on crash
+   - Max restart attempts
+
+4. Advanced
+   - Track process name
+   - Force kill
+   - Kill process tree
+
+Recomendacoes:
+
+- Manter Basic aberto por padrao.
+- Launch aberto por padrao apenas em edit ou quando houver valores preenchidos.
+- Recovery e Advanced colapsados.
+- Erros com `role="alert"` e campo com `aria-invalid`.
+- `aria-describedby` para hints.
+- Focus trap, Escape e retorno de foco ao trigger como requisito de componente modal.
+
+## Settings
+
+Separar settings em dois grupos visuais:
+
+- Monitoring: poll interval, default trigger.
+- System: autostart, notifications, language.
+
+Melhorias:
+
+- Usar stepper/input compacto para intervalo, com unidade visivel `seconds`.
+- Trigger mode deve ser segmented control com `aria-pressed` ou radio group.
+- Botao Save deve indicar estado dirty/saved; hoje ele existe mesmo quando nada mudou.
+- Switches devem usar o mesmo componente visual da tela Apps.
+
+## Activity Log
+
+O log deve ser uma ferramenta de diagnostico, nao apenas uma lista mono.
+
+Proposta:
+
+- filtros por tipo: App, iRacing, Errors, All;
+- chips de evento com largura fixa: LAUNCH, STOP, iRACING ON, iRACING OFF;
+- timestamp em `text-muted`, mensagem em `text-secondary`;
+- eventos de iRacing com icone diferente para start/stop;
+- opcao futura: copiar log ou limpar visualmente.
+
+Evitar depender de simbolos soltos como unico diferencial. O ideal e label textual distinto, por exemplo `IRACING ON` e `IRACING OFF`.
+
+## History / Sessions
+
+History deve virar Sessions:
+
+- cards ou tabela compacta por sessao;
+- duracao, horario de inicio, apps lancados;
+- estado se houve erro;
+- acao para expandir detalhes da sessao.
+
+Enquanto for mockado, visualmente deve deixar claro que e historico de sessoes, nao apenas lista estatica.
+
+## Componentes Base A Criar Antes De Refatorar
+
+Antes de mexer tela por tela, recomendo padronizar estes componentes:
+
+- `Button`: variants `primary`, `secondary`, `ghost`, `danger`, `icon`.
+- `Switch`: tamanho unico, estados on/off/disabled, labels externos.
+- `StatusPill`: variants `online`, `offline`, `running`, `idle`, `crashed`.
+- `PanelHeader`: titulo, descricao e slot de acoes.
+- `Modal`: focus trap, Escape, `aria-labelledby`, retorno de foco.
+- `Field`: label, hint, erro, `aria-describedby`, `aria-invalid`.
+- `IconButton`: area minima, tooltip, `aria-label`.
+
+Essa abordagem evita repetir a mesma decisao de contraste em cada tela.
+
+## Fluxo Do Usuario
+
+### Primeiro uso
+
+1. Abre o Pitlane.
+2. Ve status do iRacing no header.
+3. Clica em `Add app`.
+4. Preenche nome e executavel.
+5. Mantem `Enabled` e `Stop with iRacing` como defaults.
+6. Salva.
+7. App aparece na lista com estado Idle e acao Start.
+
+### Uso durante corrida
+
+1. iRacing abre e o status muda para Open/Racing.
+2. Apps configurados iniciam ou ficam disponiveis.
+3. Usuario ve contador de apps rodando no topo.
+4. Se algo falhar, o card mostra Crashed com alerta e o log registra o evento.
+5. Ao encerrar iRacing, auto-stop global e por app deixam claro o que sera parado.
+
+### Manutencao
+
+1. Usuario entra em Settings para ajustar trigger ou intervalo.
+2. Mudancas ficam locais ate salvar.
+3. Feedback de salvo aparece sem bloquear a tela.
+
+## Plano De Implementacao Sugerido
+
+1. Introduzir tokens novos em uma branch separada, sem alterar layout.
+2. Criar componentes base acessiveis.
+3. Trocar AppsScreen para usar os componentes e nova hierarquia de card.
+4. Refatorar Modal usando `Modal` e `Field`.
+5. Padronizar Settings.
+6. Melhorar Log e History/Sessions.
+7. Rodar auditoria A11Y novamente e comparar com `docs/A11Y-REPORT.md`.
+
+## Criterios De Aceite
+
+- Todas as combinacoes de texto real passam WCAG AA 4.5:1.
+- Bordas de controles interativos passam 3:1 contra o fundo adjacente.
+- Nenhum estado operacional depende apenas de cor.
+- Todos os botoes de icone tem `aria-label`.
+- Modal prende foco, fecha com Escape e devolve foco ao elemento que abriu.
+- Alvos interativos principais tem 44x44 ou area clicavel equivalente.
+- Fluxo de adicionar app pode ser concluido sem mouse.
+
+## Prompts Para Mockups Com GPT Image 2
+
+Estes prompts podem ser usados para gerar imagens de referencia visual. Eles nao devem ser tratados como especificacao final de CSS.
+
+### Mockup 1 - Apps Dashboard
+
+```text
+Use case: ui-mockup
+Asset type: desktop app UI concept
+Primary request: high fidelity mockup of Pitlane, a dark desktop control panel for managing companion apps for iRacing.
+Scene/backdrop: single desktop app window, no marketing content.
+Subject: Apps dashboard with top status bar, left sidebar, operational summary strip, and dense app list.
+Style/medium: polished product UI mockup, pragmatic utility software, compact spacing.
+Composition/framing: 16:10 landscape, full app window, first screen only.
+Color palette: deep purple dark surfaces, aqua primary accent, green running status, amber warning, red danger.
+Text (verbatim): "Pitlane", "Apps", "iRacing Offline", "Auto-stop", "Add app", "SimHub", "CrewChief", "Running", "Idle", "Start", "Stop".
+Constraints: accessible contrast, no decorative gradients, no oversized hero, no cards inside cards, no unreadable tiny text, no fake browser chrome.
+Avoid: purple-dominant palette, marketing landing page, blurred background, stock photo.
+```
+
+### Mockup 2 - Add App Modal
+
+```text
+Use case: ui-mockup
+Asset type: desktop app modal UI concept
+Primary request: high fidelity modal mockup for adding an app in Pitlane.
+Scene/backdrop: dark app UI dimmed behind a centered modal.
+Subject: structured form with sections Basic, Launch, Recovery, Advanced; accessible fields and switches.
+Style/medium: polished product UI mockup, compact and readable.
+Composition/framing: modal centered, enough background visible to understand context.
+Color palette: deep purple surfaces, aqua focus and primary save button, neutral borders, red inline error style.
+Text (verbatim): "Add app", "Name", "Executable path", "Enabled", "Stop with iRacing", "Startup delay", "Arguments", "Cancel", "Save".
+Constraints: clear focus states, readable hints, 44px close button, no cramped overlapping text.
+Avoid: form wizard, colorful gradients, oversized rounded cards.
+```
+
+### Mockup 3 - Activity And Sessions
+
+```text
+Use case: ui-mockup
+Asset type: desktop app UI concept
+Primary request: high fidelity mockup showing Pitlane Activity log and Sessions history patterns.
+Scene/backdrop: dark desktop utility app.
+Subject: split view concept with event filter tabs, mono activity feed, and compact session rows.
+Style/medium: operational diagnostics UI, readable and dense.
+Composition/framing: 16:10 landscape app window with sidebar.
+Color palette: deep purple dark surfaces, aqua info accents, green success, amber warning, red danger.
+Text (verbatim): "Activity", "All", "Apps", "iRacing", "Errors", "IRACING ON", "LAUNCH", "STOP", "Sessions", "Duration", "Apps launched".
+Constraints: accessible contrast, event type indicated by label and icon, no color-only state.
+Avoid: terminal-only screen, neon cyberpunk style, decorative charts.
+```

--- a/tmp/palette-proposal.md
+++ b/tmp/palette-proposal.md
@@ -1,0 +1,147 @@
+# Pitlane - Proposta de Paleta Acessivel
+
+Data: 2026-04-30
+
+Escopo: proposta visual. Nenhuma mudanca de codigo foi aplicada.
+
+## Diagnostico
+
+A correcao atual melhora pontos objetivos de contraste, mas preserva o problema de base: a interface depende demais de uma escala roxa escura e resolve estados com opacidade. Isso cria tres efeitos indesejados:
+
+- bordas precisam ficar muito claras para passar 3:1, parecendo mais "neon" do que estrutura;
+- textos auxiliares ficam sempre no limite entre conteudo legivel e texto desabilitado;
+- estados operacionais, como rodando, parado, iRacing aberto e erro, competem com a cor primaria.
+
+A proposta abaixo refaz a escala roxa desde a base, usando tons menos saturados e com contraste calculado contra `surface` e `elevated`. O aqua fica reservado para acao primaria, foco e estado iRacing ativo. Feedback operacional passa a usar cores semanticas separadas.
+
+## Direcao Recomendada
+
+Nome: Pitlane Aurora
+
+Intencao: uma interface de cockpit/utility, escura, densa e operacional, mantendo a identidade roxa atual com aqua como acento principal. A cor deve ajudar o usuario a responder tres perguntas rapidamente:
+
+- o iRacing esta ativo?
+- quais apps estao rodando, parados ou com erro?
+- qual e a proxima acao segura?
+
+## Tokens Propostos
+
+```css
+@theme {
+  /* Superficies */
+  --color-canvas:   #090714; /* chrome externo, header, overlays profundos */
+  --color-base:     #120b24; /* fundo principal */
+  --color-surface:  #1b1233; /* paineis, cards, listas */
+  --color-elevated: #251a43; /* hover, inputs, menus, itens ativos sutis */
+
+  /* Bordas */
+  --color-border:        #33264f; /* separadores e bordas passivas */
+  --color-border-strong: #7c6dab; /* controles interativos, 3:1+ */
+
+  /* Texto */
+  --color-text:           #f4f0ff; /* conteudo principal */
+  --color-text-secondary: #d1c5f2; /* labels, descricoes importantes */
+  --color-text-muted:     #a999d3; /* metadados e hints legiveis */
+  --color-text-disabled:  #6f618f; /* apenas desabilitado/decorativo */
+
+  /* Acao primaria e foco */
+  --color-accent:       #4dd9d0;
+  --color-accent-hover: #7ae7e0;
+  --color-focus:        #7ae7e0;
+  --color-on-accent:    #061412;
+
+  /* Status */
+  --color-success: #47d18c;
+  --color-warning: #f2c94c;
+  --color-danger:  #ff7373;
+  --color-info:    #8bb8ff;
+
+  /* Texto sobre status preenchido */
+  --color-on-success: #08120d;
+  --color-on-warning: #171104;
+  --color-on-danger:  #170607;
+  --color-on-info:    #06101b;
+}
+```
+
+## Contraste Esperado
+
+Medicoes calculadas contra as quatro superficies principais.
+
+| Token | canvas | base | surface | elevated | Uso |
+|---|---:|---:|---:|---:|---|
+| text `#f4f0ff` | 17.83 | 17.06 | 15.88 | 14.34 | texto principal |
+| text-secondary `#d1c5f2` | 12.34 | 11.81 | 10.99 | 9.93 | labels e apoio |
+| text-muted `#a999d3` | 7.78 | 7.45 | 6.93 | 6.26 | hints e metadados legiveis |
+| text-disabled `#6f618f` | 3.60 | 3.44 | 3.20 | 2.89 | desabilitado, nao conteudo |
+| accent `#4dd9d0` | 11.55 | 11.06 | 10.29 | 9.29 | acao/foco/status ativo |
+| success `#47d18c` | 10.23 | 9.80 | 9.12 | 8.23 | app rodando/sucesso |
+| warning `#f2c94c` | 12.58 | 12.04 | 11.21 | 10.12 | pausa/alerta |
+| danger `#ff7373` | 7.56 | 7.24 | 6.73 | 6.08 | erro/parar/excluir |
+| info `#8bb8ff` | 9.88 | 9.46 | 8.80 | 7.95 | informacao secundaria |
+| border-strong `#7c6dab` | 5.03 | 4.82 | 3.92 | 3.54 | borda de controle |
+
+Regra: `text-disabled` nao deve aparecer em conteudo que precisa ser lido. Para vazio, hint, timestamp, PID, descricao de setting e label de toggle, usar no minimo `text-muted`.
+
+## Aplicacao Por Elemento
+
+| Elemento | Fundo | Texto | Borda | Estado |
+|---|---|---|---|---|
+| App shell | `canvas` | `text` | `border` | header e chrome fixos |
+| Main content | `base` | `text` | n/a | area de trabalho |
+| Sidebar | `canvas` ou `base` | `text-muted` | `border` | item ativo com `accent` |
+| Header da tela | transparente/base | `text` + `text-muted` | `border` | titulo e resumo |
+| Card de app | `surface` | `text` | `border` | hover: `elevated` |
+| Card ativo/rodando | `surface` | `text` | `success` ou left rail success | sem depender so da cor |
+| Input | `elevated` | `text` | `border-strong` | foco: `focus` + ring |
+| Select/menu | `elevated` | `text` | `border-strong` | item ativo: `accent` |
+| Botao primario | `accent` | `on-accent` | transparente | hover: `accent-hover` |
+| Botao secundario | transparente | `text-secondary` | `border-strong` | hover: `elevated` |
+| Botao destrutivo | `danger` ou `danger/15` | `on-danger` ou `danger` | `danger` | nunca usar apenas vermelho opaco |
+| Toggle ligado | `accent` | n/a | `accent` | thumb `on-accent` ou canvas |
+| Toggle desligado | `elevated` | n/a | `border-strong` | thumb `text-muted` |
+| Modal | `surface` | `text` | `border-strong` | overlay `canvas/75` |
+| Log | `base` | mono `text-muted` | n/a | labels semanticos por chip/texto |
+
+## Estados Semanticos
+
+| Estado | Cor | Forma visual obrigatoria |
+|---|---|---|
+| iRacing online | `accent` | pill com icone/ponto preenchido e texto "iRacing open/racing" |
+| iRacing offline | `text-muted` | pill neutra com ponto vazado ou icon diferente |
+| App running | `success` | indicador + botao Stop disponivel + label Running |
+| App idle | `text-muted` | indicador neutro + label Idle |
+| App crashed | `warning` | icone alerta + label Crashed |
+| Delete/Stop destrutivo | `danger` | icone Square/Trash + texto; nao depender so da cor |
+| Disabled app | opacidade leve + badge "Disabled" | manter texto legivel, evitar `opacity-50` no card inteiro |
+
+## Ajustes Recomendados Nos Tokens Atuais
+
+1. Substituir a escala roxa de superficie atual por `Pitlane Aurora`.
+2. Manter `text-disabled` apenas para thumb de toggle desligado, placeholder decorativo e icones sem significado.
+3. Trocar botoes primarios de `bg-accent/15 text-accent` por botao preenchido `bg-accent text-on-accent` quando a acao for principal.
+4. Evitar usar `accent` para avatar, status iRacing, botao primario, log e selecionado ao mesmo tempo. Avatares devem usar uma escala propria e menos competitiva.
+5. Definir `focus` separado de `accent` para que foco de teclado nao seja confundido com selecao.
+
+## Alternativas Consideradas
+
+### Manter roxo e corrigir contraste
+
+Vantagem: menor mudanca visual. Problema: `border-strong` precisa ficar claro demais, e a interface continua monocromatica. E a alternativa mais barata, mas nao resolve a direcao visual.
+
+### Azul cockpit
+
+Vantagem: combina com telemetria/simulador. Problema: tende a virar uma UI slate/azul generica e pode competir com iRacing/status. Nao recomendo como base.
+
+### Purple + aqua recalculado
+
+Vantagem: melhora contraste, preserva a identidade roxa+aqua, separa status de estrutura e reduz dependencia de opacidade. Recomendada.
+
+## Checklist Para Validar Antes De Implementar
+
+- `border-strong` precisa passar 3:1 sobre `surface` e `elevated`.
+- `text-muted` precisa passar 4.5:1 sobre `surface` e `elevated`.
+- Nenhum texto real deve usar `text-disabled`.
+- Botoes de icone precisam ter area minima de 44x44 ou area clicavel equivalente.
+- Estados ativos precisam ter texto, icone ou posicao, nao apenas cor.
+- Focus ring deve ser visivel em todos os controles sobre `surface` e `elevated`.


### PR DESCRIPTION
## Overview

This PR started as an accessibility contrast pass and evolved into a broader UI/theme cleanup for Pitlane. The main outcome is that color, state, and action styling are now driven by clearer theme tokens instead of one-off class changes.

It also improves the Apps screen interaction model: app status is easier to scan, disabled auto-start no longer blocks manual app control, and the global iRacing close behavior is labeled around what the toggle actually does.

## What changed

### Theme system

- Adds a theme registry with persisted selection via `localStorage`.
- Adds a theme selector next to the language selector and in Settings.
- Removes the old legacy purple theme from the selector.
- Adds two selectable themes:
  - `Pitlane Aurora`: deep purple surfaces with aqua accents.
  - `Pitlane Nebula`: dark aqua surfaces with purple accents.
- Reworks `index.css` around primitive color ramps plus semantic UI tokens.

### Apps screen

- Replaces tiny status dots with readable status badges and icons.
- Adds a distinct `Disabled` badge for apps that are not auto-started with iRacing.
- Darkens disabled app cards via `surface-disabled`, while keeping manual controls usable.
- Keeps Start/Stop/Edit/Delete available for manually managing apps even when auto-start is disabled.
- Disables only the dependent per-app `Stop with iRacing` switch when auto-start is disabled.
- Converts the global iRacing-close control into an inverted switch:
  - ON = `DO NOT stop apps when iRacing closes`
  - OFF = allow configured apps to stop when iRacing closes

### UI accessibility and visual polish

- Uses solid button backgrounds instead of low-opacity accent fills for primary/destructive actions.
- Adds stronger hover states for solid buttons.
- Improves icon visibility with larger icons and heavier strokes.
- Updates toggles so OFF remains visibly interactive; only disabled toggles use the muted gray treatment.
- Keeps state communication from relying only on color by pairing labels with icons.
- Improves text contrast and removes `text-disabled` from readable UI content.

### Tauri window

- Sets the native app window minimum size to `750x230`.

### Documentation

- Adds theme/interface proposal notes under `tmp/`.
- Adds a reusable PR description template at `.github/PULL_REQUEST_TEMPLATE.md`.
- Keeps the A11Y audit checklist available for follow-up work.

## Why

The original contrast-only patch fixed several WCAG failures, but it still left the UI dependent on isolated token swaps and subtle opacity-based states. This PR moves the project toward a themeable design system where the same UI can be evaluated across palettes without rewriting component classes.

The Apps screen also needed clearer semantics: disabling auto-start should not imply that the app cannot be started manually, and the global auto-stop switch needed wording that clearly explains its inverted behavior.

## Screenshots / media

N/A for now. Recommended manual review is to run the Tauri app and compare `Pitlane Aurora` and `Pitlane Nebula` in the Apps screen.

## Test plan

- [x] `npm run build`
- [x] `npm test` — 27 tests passing
- [ ] Manual visual check: theme selector switches between Aurora and Nebula.
- [ ] Manual visual check: disabled app card uses darker background and shows `Disabled` badge.
- [ ] Manual visual check: Start/Stop/Edit/Delete remain usable when auto-start is off.
- [ ] Manual visual check: per-app `Stop with iRacing` is disabled when auto-start is off.
- [ ] Manual visual check: global `DO NOT stop apps when iRacing closes` switch stores the inverted backend value.
- [ ] Manual resize check: native Tauri window respects `750x230` minimum size.

## Risk and rollout notes

- Theme selection is stored in `localStorage` under `pitlane_theme`.
- Any old saved theme value such as `pitlane-purple` falls back to `Pitlane Aurora`.
- The backend `auto_stop` value was not changed; the UI intentionally inverts the global switch semantics.
- The PR includes UI behavior changes beyond contrast fixes, so visual review should focus on the Apps screen.

## Review focus

- Confirm the inverted global auto-stop wording is understandable.
- Review Aurora/Nebula token choices for contrast and visual balance.
- Check whether disabled auto-start card behavior matches the intended manual-control workflow.
- Verify the PR template is useful enough as the default for future changes.

