### PR TITLE
refactor(ui): extract shared component library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+tmp
 
 # Claude Code
 .claude/

--- a/src/__tests__/ui/Button.test.tsx
+++ b/src/__tests__/ui/Button.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Button } from "@/components/ui/Button";
+
+describe("Button", () => {
+  it("renders children", () => {
+    render(<Button>Save</Button>);
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+
+  it("calls onClick when clicked", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Save</Button>);
+    await user.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClick when disabled", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<Button disabled onClick={onClick}>Save</Button>);
+    await user.click(screen.getByRole("button"));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("applies accent variant classes by default", () => {
+    render(<Button>Save</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toContain("bg-accent-solid");
+  });
+
+  it("applies danger variant classes", () => {
+    render(<Button variant="danger">Delete</Button>);
+    expect(screen.getByRole("button").className).toContain("bg-danger-solid");
+  });
+
+  it("applies success variant classes", () => {
+    render(<Button variant="success">Start</Button>);
+    expect(screen.getByRole("button").className).toContain("bg-success-solid");
+  });
+
+  it("applies ghost variant classes", () => {
+    render(<Button variant="ghost">Cancel</Button>);
+    expect(screen.getByRole("button").className).toContain("border-border-strong");
+  });
+
+  it("merges custom className", () => {
+    render(<Button className="mt-4">Save</Button>);
+    expect(screen.getByRole("button").className).toContain("mt-4");
+  });
+
+  it("snapshot — default accent", () => {
+    const { container } = render(<Button>Save</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("snapshot — danger md", () => {
+    const { container } = render(<Button variant="danger" size="md">Delete</Button>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("snapshot — icon", () => {
+    const { container } = render(<Button variant="icon" aria-label="edit" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/ui/Dropdown.test.tsx
+++ b/src/__tests__/ui/Dropdown.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Dropdown } from "@/components/ui/Dropdown";
+
+function makeDropdown(onSelect = vi.fn()) {
+  return (
+    <Dropdown trigger={(open) => <button>Trigger {open ? "open" : "closed"}</button>}>
+      <button onClick={onSelect}>Option A</button>
+      <button>Option B</button>
+    </Dropdown>
+  );
+}
+
+describe("Dropdown", () => {
+  it("renders trigger, hides menu by default", () => {
+    render(makeDropdown());
+    expect(screen.getByText("Trigger closed")).toBeInTheDocument();
+    expect(screen.queryByText("Option A")).not.toBeInTheDocument();
+  });
+
+  it("opens menu on trigger click", async () => {
+    const user = userEvent.setup();
+    render(makeDropdown());
+    await user.click(screen.getByText("Trigger closed"));
+    expect(screen.getByText("Option A")).toBeInTheDocument();
+    expect(screen.getByText("Trigger open")).toBeInTheDocument();
+  });
+
+  it("closes menu after selecting an item", async () => {
+    const user = userEvent.setup();
+    render(makeDropdown());
+    await user.click(screen.getByText("Trigger closed"));
+    await user.click(screen.getByText("Option A"));
+    expect(screen.queryByText("Option A")).not.toBeInTheDocument();
+  });
+
+  it("calls item handler when item is selected", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(makeDropdown(onSelect));
+    await user.click(screen.getByText("Trigger closed"));
+    await user.click(screen.getByText("Option A"));
+    expect(onSelect).toHaveBeenCalledOnce();
+  });
+
+  it("closes on click outside", async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        {makeDropdown()}
+        <button>Outside</button>
+      </div>
+    );
+    await user.click(screen.getByText("Trigger closed"));
+    expect(screen.getByText("Option A")).toBeInTheDocument();
+    await user.click(screen.getByText("Outside"));
+    expect(screen.queryByText("Option A")).not.toBeInTheDocument();
+  });
+
+  it("snapshot — closed", () => {
+    const { container } = render(makeDropdown());
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("snapshot — open", async () => {
+    const user = userEvent.setup();
+    const { container } = render(makeDropdown());
+    await user.click(screen.getByText("Trigger closed"));
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/ui/Modal.test.tsx
+++ b/src/__tests__/ui/Modal.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Modal } from "@/components/ui/Modal";
+
+describe("Modal", () => {
+  it("renders children", () => {
+    render(<Modal onClickOutside={vi.fn()}><p>Content</p></Modal>);
+    expect(screen.getByText("Content")).toBeInTheDocument();
+  });
+
+  it("has dialog role and aria-modal", () => {
+    render(<Modal onClickOutside={vi.fn()}><p>Content</p></Modal>);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("calls onClickOutside when clicking the overlay", async () => {
+    const user = userEvent.setup();
+    const onClickOutside = vi.fn();
+    render(<Modal onClickOutside={onClickOutside}><p>Content</p></Modal>);
+    await user.click(screen.getByRole("dialog"));
+    expect(onClickOutside).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClickOutside when clicking content inside", async () => {
+    const user = userEvent.setup();
+    const onClickOutside = vi.fn();
+    render(
+      <Modal onClickOutside={onClickOutside}>
+        <div><button>Inner</button></div>
+      </Modal>
+    );
+    await user.click(screen.getByRole("button", { name: "Inner" }));
+    expect(onClickOutside).not.toHaveBeenCalled();
+  });
+
+  it("snapshot", () => {
+    const { container } = render(
+      <Modal onClickOutside={vi.fn()}>
+        <div>Dialog content</div>
+      </Modal>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/ui/Toggle.test.tsx
+++ b/src/__tests__/ui/Toggle.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Toggle } from "@/components/ui/Toggle";
+
+describe("Toggle", () => {
+  it("renders with correct role and aria-checked when on", () => {
+    render(<Toggle checked onChange={vi.fn()} label="Auto start" />);
+    const toggle = screen.getByRole("switch", { name: "Auto start" });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("renders with aria-checked false when off", () => {
+    render(<Toggle checked={false} onChange={vi.fn()} label="Auto start" />);
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("calls onChange with toggled value when clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Toggle checked={false} onChange={onChange} label="Auto start" />);
+    await user.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("does not call onChange when disabled", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Toggle checked={false} onChange={onChange} label="Auto start" disabled />);
+    await user.click(screen.getByRole("switch"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("is disabled when disabled prop is set", () => {
+    render(<Toggle checked={false} onChange={vi.fn()} label="Auto start" disabled />);
+    expect(screen.getByRole("switch")).toBeDisabled();
+  });
+
+  it("snapshot — on", () => {
+    const { container } = render(<Toggle checked onChange={vi.fn()} label="Auto start" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("snapshot — off", () => {
+    const { container } = render(<Toggle checked={false} onChange={vi.fn()} label="Auto start" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("snapshot — disabled", () => {
+    const { container } = render(<Toggle checked={false} onChange={vi.fn()} label="Auto start" disabled />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/ui/__snapshots__/Button.test.tsx.snap
+++ b/src/__tests__/ui/__snapshots__/Button.test.tsx.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Button > snapshot — danger md 1`] = `
+<button
+  class="inline-flex items-center justify-center gap-1.5 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed rounded-md border border-danger-solid bg-danger-solid text-on-danger hover:bg-danger-solid-hover px-3 py-1.5 text-sm"
+>
+  Delete
+</button>
+`;
+
+exports[`Button > snapshot — default accent 1`] = `
+<button
+  class="inline-flex items-center justify-center gap-1.5 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed rounded-md border border-accent-solid bg-accent-solid text-on-accent hover:bg-accent-solid-hover px-3 py-1.5 text-sm"
+>
+  Save
+</button>
+`;
+
+exports[`Button > snapshot — icon 1`] = `
+<button
+  aria-label="edit"
+  class="inline-flex items-center justify-center gap-1.5 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed rounded text-text-secondary hover:text-text hover:bg-elevated text-sm p-1.5"
+/>
+`;

--- a/src/__tests__/ui/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/__tests__/ui/__snapshots__/Dropdown.test.tsx.snap
@@ -1,0 +1,37 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Dropdown > snapshot — closed 1`] = `
+<div
+  class="relative"
+>
+  <div>
+    <button>
+      Trigger 
+      closed
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Dropdown > snapshot — open 1`] = `
+<div
+  class="relative"
+>
+  <div>
+    <button>
+      Trigger 
+      open
+    </button>
+  </div>
+  <div
+    class="absolute right-0 top-full mt-1.5 z-50 bg-elevated border border-border-strong rounded-lg shadow-xl min-w-[152px] py-1 overflow-hidden"
+  >
+    <button>
+      Option A
+    </button>
+    <button>
+      Option B
+    </button>
+  </div>
+</div>
+`;

--- a/src/__tests__/ui/__snapshots__/Modal.test.tsx.snap
+++ b/src/__tests__/ui/__snapshots__/Modal.test.tsx.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Modal > snapshot 1`] = `
+<div
+  aria-modal="true"
+  class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+  role="dialog"
+>
+  <div>
+    Dialog content
+  </div>
+</div>
+`;

--- a/src/__tests__/ui/__snapshots__/Toggle.test.tsx.snap
+++ b/src/__tests__/ui/__snapshots__/Toggle.test.tsx.snap
@@ -1,0 +1,44 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Toggle > snapshot — disabled 1`] = `
+<button
+  aria-checked="false"
+  aria-label="Auto start"
+  class="flex h-5 w-9 items-center rounded-full p-0.5 transition-colors shrink-0 disabled:cursor-not-allowed border border-border bg-elevated"
+  disabled=""
+  role="switch"
+  type="button"
+>
+  <span
+    class="h-4 w-4 rounded-full transition-transform translate-x-0 bg-text-disabled"
+  />
+</button>
+`;
+
+exports[`Toggle > snapshot — off 1`] = `
+<button
+  aria-checked="false"
+  aria-label="Auto start"
+  class="flex h-5 w-9 items-center rounded-full p-0.5 transition-colors shrink-0 disabled:cursor-not-allowed border border-accent-solid bg-elevated hover:bg-surface"
+  role="switch"
+  type="button"
+>
+  <span
+    class="h-4 w-4 rounded-full transition-transform translate-x-0 bg-accent-solid"
+  />
+</button>
+`;
+
+exports[`Toggle > snapshot — on 1`] = `
+<button
+  aria-checked="true"
+  aria-label="Auto start"
+  class="flex h-5 w-9 items-center rounded-full p-0.5 transition-colors shrink-0 disabled:cursor-not-allowed bg-accent-solid hover:bg-accent-solid-hover"
+  role="switch"
+  type="button"
+>
+  <span
+    class="h-4 w-4 rounded-full transition-transform translate-x-4 bg-on-accent"
+  />
+</button>
+`;

--- a/src/__tests__/ui/__snapshots__/snapshots.test.tsx.snap
+++ b/src/__tests__/ui/__snapshots__/snapshots.test.tsx.snap
@@ -1,0 +1,406 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AppAvatar snapshot > color cycles by char code 1`] = `
+<div
+  class="w-8 h-8 rounded-lg flex items-center justify-center text-xs font-bold shrink-0 select-none bg-success/20 text-success"
+>
+  A
+</div>
+`;
+
+exports[`AppAvatar snapshot > color cycles by char code 2`] = `
+<div
+  class="w-8 h-8 rounded-lg flex items-center justify-center text-xs font-bold shrink-0 select-none bg-warning/20 text-warning"
+>
+  B
+</div>
+`;
+
+exports[`AppAvatar snapshot > renders first letter 1`] = `
+<div
+  class="w-8 h-8 rounded-lg flex items-center justify-center text-xs font-bold shrink-0 select-none bg-danger/20 text-danger"
+>
+  S
+</div>
+`;
+
+exports[`Badge snapshots > StatusBadge crashed 1`] = `
+<span
+  class="inline-flex items-center gap-1.5 rounded border bg-elevated px-1.5 py-0.5 text-xs font-medium border-warning text-warning"
+>
+  <svg
+    aria-hidden="true"
+    class="lucide lucide-triangle-alert h-3.5 w-3.5 shrink-0 stroke-[2.5]"
+    fill="none"
+    height="24"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+    />
+    <path
+      d="M12 9v4"
+    />
+    <path
+      d="M12 17h.01"
+    />
+  </svg>
+  Crashed
+</span>
+`;
+
+exports[`Badge snapshots > StatusBadge disabled 1`] = `
+<span
+  class="inline-flex items-center gap-1.5 rounded border bg-elevated px-1.5 py-0.5 text-xs font-medium border-border-strong text-text-muted"
+>
+  <svg
+    aria-hidden="true"
+    class="lucide lucide-ban h-3.5 w-3.5 shrink-0 stroke-[2.5]"
+    fill="none"
+    height="24"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle
+      cx="12"
+      cy="12"
+      r="10"
+    />
+    <path
+      d="M4.929 4.929 19.07 19.071"
+    />
+  </svg>
+  Disabled
+</span>
+`;
+
+exports[`Badge snapshots > StatusBadge idle 1`] = `
+<span
+  class="inline-flex items-center gap-1.5 rounded border bg-elevated px-1.5 py-0.5 text-xs font-medium border-border-strong text-text-secondary"
+>
+  <svg
+    aria-hidden="true"
+    class="lucide lucide-clock3 lucide-clock-3 h-3.5 w-3.5 shrink-0 stroke-[2.5]"
+    fill="none"
+    height="24"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle
+      cx="12"
+      cy="12"
+      r="10"
+    />
+    <path
+      d="M12 6v6h4"
+    />
+  </svg>
+  Idle
+</span>
+`;
+
+exports[`Badge snapshots > StatusBadge running 1`] = `
+<span
+  class="inline-flex items-center gap-1.5 rounded border bg-elevated px-1.5 py-0.5 text-xs font-medium border-success text-success"
+>
+  <svg
+    aria-hidden="true"
+    class="lucide lucide-activity h-3.5 w-3.5 shrink-0 stroke-[2.5]"
+    fill="none"
+    height="24"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"
+    />
+  </svg>
+  Running
+</span>
+`;
+
+exports[`Badge snapshots > Tag 1`] = `
+<span
+  class="text-xs px-1.5 py-0.5 rounded bg-elevated text-text-secondary"
+>
+  SimHub
+</span>
+`;
+
+exports[`Checkbox snapshots > checked 1`] = `
+<label
+  class="flex items-start gap-2.5 cursor-pointer group"
+>
+  <div
+    class="mt-0.5 w-4 h-4 rounded border shrink-0 flex items-center justify-center transition-colors border-accent-solid bg-accent-solid"
+  >
+    <input
+      checked=""
+      class="sr-only"
+      type="checkbox"
+    />
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-check w-3 h-3 text-on-accent stroke-[2.5]"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M20 6 9 17l-5-5"
+      />
+    </svg>
+  </div>
+  <div>
+    <p
+      class="text-sm text-text leading-tight"
+    >
+      Restart on crash
+    </p>
+  </div>
+</label>
+`;
+
+exports[`Checkbox snapshots > unchecked 1`] = `
+<label
+  class="flex items-start gap-2.5 cursor-pointer group"
+>
+  <div
+    class="mt-0.5 w-4 h-4 rounded border shrink-0 flex items-center justify-center transition-colors border-border-strong bg-elevated group-hover:border-accent/50"
+  >
+    <input
+      class="sr-only"
+      type="checkbox"
+    />
+  </div>
+  <div>
+    <p
+      class="text-sm text-text leading-tight"
+    >
+      Restart on crash
+    </p>
+  </div>
+</label>
+`;
+
+exports[`Checkbox snapshots > with hint 1`] = `
+<label
+  class="flex items-start gap-2.5 cursor-pointer group"
+>
+  <div
+    class="mt-0.5 w-4 h-4 rounded border shrink-0 flex items-center justify-center transition-colors border-border-strong bg-elevated group-hover:border-accent/50"
+  >
+    <input
+      class="sr-only"
+      type="checkbox"
+    />
+  </div>
+  <div>
+    <p
+      class="text-sm text-text leading-tight"
+    >
+      Force kill
+    </p>
+    <p
+      class="text-xs text-text-muted mt-0.5"
+    >
+      Skips WM_CLOSE
+    </p>
+  </div>
+</label>
+`;
+
+exports[`EmptyState snapshot > with action 1`] = `
+<div
+  class="flex-1 flex flex-col items-center justify-center text-text-muted gap-3 h-full"
+>
+  <svg
+    aria-hidden="true"
+    class="lucide lucide-activity w-8 h-8"
+    fill="none"
+    height="24"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"
+    />
+  </svg>
+  <div
+    class="flex flex-col items-center gap-2"
+  >
+    <p
+      class="text-sm"
+    >
+      No apps yet
+    </p>
+    <button>
+      Add app
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EmptyState snapshot > without action 1`] = `
+<div
+  class="flex-1 flex flex-col items-center justify-center text-text-muted gap-3 h-full"
+>
+  <svg
+    aria-hidden="true"
+    class="lucide lucide-activity w-8 h-8"
+    fill="none"
+    height="24"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"
+    />
+  </svg>
+  <div
+    class="flex flex-col items-center gap-2"
+  >
+    <p
+      class="text-sm"
+    >
+      No apps yet
+    </p>
+  </div>
+</div>
+`;
+
+exports[`FormField snapshot > with hint 1`] = `
+<div
+  class="flex flex-col gap-1"
+>
+  <label
+    class="text-xs text-text-muted"
+  >
+    Name
+  </label>
+  <input />
+  <p
+    class="text-xs text-text-muted"
+  >
+    Display name
+  </p>
+</div>
+`;
+
+exports[`FormField snapshot > with label only 1`] = `
+<div
+  class="flex flex-col gap-1"
+>
+  <label
+    class="text-xs text-text-muted"
+  >
+    Name
+  </label>
+  <input />
+</div>
+`;
+
+exports[`Input snapshots > NumberInput 1`] = `
+<input
+  class="text-sm bg-elevated border border-border-strong rounded-md px-3 py-1.5 text-text outline-none focus:border-accent placeholder:text-text-disabled transition-colors w-28"
+  min="1"
+  step="1"
+  type="number"
+  value="3"
+/>
+`;
+
+exports[`Input snapshots > TextInput default 1`] = `
+<input
+  class="text-sm bg-elevated border border-border-strong rounded-md px-3 py-1.5 text-text outline-none focus:border-accent placeholder:text-text-disabled transition-colors"
+  type="text"
+  value="SimHub"
+/>
+`;
+
+exports[`Input snapshots > TextInput mono 1`] = `
+<input
+  class="bg-elevated border border-border-strong rounded-md px-3 py-1.5 text-text outline-none focus:border-accent placeholder:text-text-disabled transition-colors font-mono text-xs"
+  type="text"
+  value="C:/SimHub/SimHub.exe"
+/>
+`;
+
+exports[`ScreenHeader snapshot > title only 1`] = `
+<div
+  class="flex items-center justify-between px-4 py-3 border-b border-border shrink-0"
+>
+  <h2
+    class="text-sm font-semibold text-text"
+  >
+    Apps
+  </h2>
+</div>
+`;
+
+exports[`ScreenHeader snapshot > with action 1`] = `
+<div
+  class="flex items-center justify-between px-4 py-3 border-b border-border shrink-0"
+>
+  <h2
+    class="text-sm font-semibold text-text"
+  >
+    History
+  </h2>
+  <button>
+    Clear
+  </button>
+</div>
+`;
+
+exports[`SectionDivider snapshot > renders 1`] = `
+<div
+  class="flex items-center gap-2 pt-1"
+>
+  <span
+    class="text-xs font-semibold uppercase tracking-widest text-text-muted"
+  >
+    Basic
+  </span>
+  <div
+    class="flex-1 h-px bg-border"
+  />
+</div>
+`;

--- a/src/__tests__/ui/snapshots.test.tsx
+++ b/src/__tests__/ui/snapshots.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { Activity } from "lucide-react";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { TextInput, NumberInput } from "@/components/ui/Input";
+import { StatusBadge, Tag } from "@/components/ui/Badge";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { SectionDivider } from "@/components/ui/SectionDivider";
+import { FormField } from "@/components/layout/FormField";
+import { ScreenHeader } from "@/components/layout/ScreenHeader";
+import { AppAvatar } from "@/components/AppAvatar";
+
+describe("Checkbox snapshots", () => {
+  it("unchecked", () => {
+    const { container } = render(<Checkbox label="Restart on crash" checked={false} onChange={vi.fn()} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("checked", () => {
+    const { container } = render(<Checkbox label="Restart on crash" checked onChange={vi.fn()} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("with hint", () => {
+    const { container } = render(
+      <Checkbox label="Force kill" hint="Skips WM_CLOSE" checked={false} onChange={vi.fn()} />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe("Input snapshots", () => {
+  it("TextInput default", () => {
+    const { container } = render(<TextInput value="SimHub" onChange={vi.fn()} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("TextInput mono", () => {
+    const { container } = render(<TextInput value="C:/SimHub/SimHub.exe" onChange={vi.fn()} mono />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("NumberInput", () => {
+    const { container } = render(<NumberInput value={3} onChange={vi.fn()} min={1} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe("Badge snapshots", () => {
+  it("StatusBadge running", () => {
+    const { container } = render(
+      <StatusBadge status={{ app_id: "1", state: { type: "running", pid: 1234 } }} enabled label="Running" />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("StatusBadge crashed", () => {
+    const { container } = render(
+      <StatusBadge status={{ app_id: "1", state: { type: "crashed" } }} enabled label="Crashed" />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("StatusBadge idle", () => {
+    const { container } = render(
+      <StatusBadge status={undefined} enabled label="Idle" />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("StatusBadge disabled", () => {
+    const { container } = render(
+      <StatusBadge status={undefined} enabled={false} label="Disabled" />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("Tag", () => {
+    const { container } = render(<Tag>SimHub</Tag>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe("EmptyState snapshot", () => {
+  it("without action", () => {
+    const { container } = render(<EmptyState icon={Activity} message="No apps yet" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("with action", () => {
+    const { container } = render(
+      <EmptyState icon={Activity} message="No apps yet" action={<button>Add app</button>} />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe("SectionDivider snapshot", () => {
+  it("renders", () => {
+    const { container } = render(<SectionDivider title="Basic" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe("FormField snapshot", () => {
+  it("with label only", () => {
+    const { container } = render(
+      <FormField label="Name"><input /></FormField>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("with hint", () => {
+    const { container } = render(
+      <FormField label="Name" hint="Display name"><input /></FormField>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe("ScreenHeader snapshot", () => {
+  it("title only", () => {
+    const { container } = render(<ScreenHeader title="Apps" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("with action", () => {
+    const { container } = render(
+      <ScreenHeader title="History" action={<button>Clear</button>} />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe("AppAvatar snapshot", () => {
+  it("renders first letter", () => {
+    const { container } = render(<AppAvatar name="SimHub" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("color cycles by char code", () => {
+    const { container: c1 } = render(<AppAvatar name="A" />);
+    const { container: c2 } = render(<AppAvatar name="B" />);
+    expect(c1.firstChild).toMatchSnapshot();
+    expect(c2.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/AppAvatar.tsx
+++ b/src/components/AppAvatar.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/cn";
+
+const AVATAR_COLORS = [
+  "bg-accent/20 text-accent",
+  "bg-success/20 text-success",
+  "bg-warning/20 text-warning",
+  "bg-danger/20 text-danger",
+];
+
+interface AppAvatarProps {
+  name: string;
+}
+
+export function AppAvatar({ name }: AppAvatarProps) {
+  const idx = (name.charCodeAt(0) ?? 0) % AVATAR_COLORS.length;
+  return (
+    <div className={cn("w-8 h-8 rounded-lg flex items-center justify-center text-xs font-bold shrink-0 select-none", AVATAR_COLORS[idx])}>
+      {name[0]?.toUpperCase() ?? "?"}
+    </div>
+  );
+}

--- a/src/components/AppCard.tsx
+++ b/src/components/AppCard.tsx
@@ -1,0 +1,111 @@
+import { Pencil, Play, Square, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/cn";
+import type { AppStatus, ManagedApp } from "@/lib/api";
+import { StatusBadge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Toggle } from "@/components/ui/Toggle";
+import { AppAvatar } from "@/components/AppAvatar";
+
+interface AppCardProps {
+  app: ManagedApp;
+  status: AppStatus | undefined;
+  onStart: () => void;
+  onStop: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggleEnabled: (enabled: boolean) => void;
+  onToggleStopWithIracing: (stop: boolean) => void;
+}
+
+function pidDetail(status: AppStatus | undefined): string | null {
+  if (status?.state.type !== "running") return null;
+  return `PID ${(status.state as { pid: number }).pid}`;
+}
+
+export function AppCard({ app, status, onStart, onStop, onEdit, onDelete, onToggleEnabled, onToggleStopWithIracing }: AppCardProps) {
+  const { t } = useTranslation();
+  const running = status?.state.type === "running";
+  const detail = pidDetail(status);
+  const appDisabled = !app.enabled;
+
+  const statusLabel = !app.enabled
+    ? t("apps.status.disabled")
+    : t(`apps.status.${status?.state.type ?? "idle"}`);
+
+  return (
+    <li
+      data-testid="app-card"
+      className={cn(
+        "flex flex-col rounded-lg border bg-surface border-border-strong transition-colors",
+        appDisabled && "border-border bg-surface-disabled",
+      )}
+    >
+      {/* Row 1: avatar / name / status / actions */}
+      <div className="flex items-center gap-3 px-3 py-2.5">
+        <div className={cn(appDisabled && "opacity-55")}>
+          <AppAvatar name={app.name} />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex flex-col gap-1">
+            <span className={cn("text-sm font-medium text-text truncate", appDisabled && "opacity-60")}>
+              {app.name}
+            </span>
+            <div className="flex items-center gap-2 min-h-5">
+              <StatusBadge status={status} enabled={app.enabled} label={statusLabel} />
+              {detail && (
+                <span className="text-xs text-text-muted truncate font-mono" title={detail}>
+                  {detail}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 shrink-0">
+          {running ? (
+            <Button variant="danger" onClick={onStop} title={t("apps.stop")}>
+              <Square className="w-3.5 h-3.5 fill-current stroke-[2.5]" />
+              {t("apps.stop")}
+            </Button>
+          ) : (
+            <Button variant="success" onClick={onStart} title={t("apps.start")}>
+              <Play className="w-3.5 h-3.5 fill-current stroke-[2.5]" />
+              {t("apps.start")}
+            </Button>
+          )}
+
+          <Button variant="icon" onClick={onEdit} title={t("apps.edit")}>
+            <Pencil className="w-4 h-4 stroke-[2.5]" />
+          </Button>
+
+          <button
+            title={t("apps.delete")}
+            onClick={onDelete}
+            className="p-1.5 rounded text-danger hover:bg-danger/10 transition-colors"
+          >
+            <Trash2 className="w-4 h-4 stroke-[2.5]" />
+          </button>
+        </div>
+      </div>
+
+      {/* Row 2: auto-start / auto-stop toggles */}
+      <div className="flex items-center justify-between px-3 pb-2.5 -mt-0.5 gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-text-secondary">{t("apps.auto_start")}</span>
+          <Toggle checked={app.enabled} onChange={onToggleEnabled} label={t("apps.auto_start")} />
+        </div>
+        <div className={cn("flex items-center gap-2", appDisabled && "opacity-60")}>
+          <span className="text-xs text-text-muted">{t("apps.auto_stop")}</span>
+          <Toggle
+            checked={app.stop_with_iracing}
+            disabled={appDisabled}
+            onChange={onToggleStopWithIracing}
+            label={t("apps.auto_stop")}
+          />
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/src/components/AppFormModal.tsx
+++ b/src/components/AppFormModal.tsx
@@ -3,6 +3,12 @@ import { Check, ChevronDown, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
 import { type ManagedApp, type NewApp } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { Modal } from "@/components/ui/Modal";
+import { TextInput, NumberInput } from "@/components/ui/Input";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { SectionDivider } from "@/components/ui/SectionDivider";
+import { FormField } from "@/components/layout/FormField";
 
 interface AppFormModalProps {
   mode: "add" | "edit";
@@ -41,100 +47,6 @@ function initForm(initial?: ManagedApp): FormState {
     kill_process_tree:    initial?.kill_process_tree    ?? false,
     stop_with_iracing:    initial?.stop_with_iracing    ?? true,
   };
-}
-
-function SectionDivider({ title }: { title: string }) {
-  return (
-    <div className="flex items-center gap-2 pt-1">
-      <span className="text-xs font-semibold uppercase tracking-widest text-text-muted">
-        {title}
-      </span>
-      <div className="flex-1 h-px bg-border" />
-    </div>
-  );
-}
-
-function Field({ label, hint, id, children }: { label: string; hint?: string; id?: string; children: React.ReactNode }) {
-  return (
-    <div className="flex flex-col gap-1">
-      <label htmlFor={id} className="text-xs text-text-muted">{label}</label>
-      {children}
-      {hint && <p className="text-xs text-text-muted">{hint}</p>}
-    </div>
-  );
-}
-
-function TextInput({
-  id, value, onChange, placeholder, mono = false,
-}: {
-  id?: string; value: string; onChange: (v: string) => void; placeholder?: string; mono?: boolean;
-}) {
-  return (
-    <input
-      id={id}
-      type="text"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      placeholder={placeholder}
-      className={cn(
-        "text-sm bg-elevated border border-border-strong rounded-md px-3 py-1.5 text-text",
-        "outline-none focus:border-accent placeholder:text-text-disabled transition-colors",
-        mono && "font-mono text-xs",
-      )}
-    />
-  );
-}
-
-function NumberInput({
-  value, onChange, min = 0, step = 1,
-}: {
-  value: number; onChange: (v: number) => void; min?: number; step?: number;
-}) {
-  return (
-    <input
-      type="number"
-      value={value}
-      onChange={(e) => onChange(Number(e.target.value))}
-      min={min}
-      step={step}
-      className="w-28 text-sm bg-elevated border border-border-strong rounded-md px-3 py-1.5 text-text outline-none focus:border-accent transition-colors"
-    />
-  );
-}
-
-function CheckRow({
-  label, hint, checked, onChange,
-}: {
-  label: string; hint?: string; checked: boolean; onChange: (v: boolean) => void;
-}) {
-  return (
-    <label className="flex items-start gap-2.5 cursor-pointer group">
-      <div
-        className={cn(
-          "mt-0.5 w-4 h-4 rounded border shrink-0 flex items-center justify-center transition-colors",
-          checked
-            ? "bg-accent-solid border-accent-solid"
-            : "bg-elevated border-border-strong group-hover:border-accent/50",
-        )}
-      >
-        <input
-          type="checkbox"
-          checked={checked}
-          onChange={(e) => onChange(e.target.checked)}
-          className="sr-only"
-        />
-        {checked && (
-          <svg className="w-3 h-3 text-on-accent" viewBox="0 0 12 12" fill="none">
-            <path d="M2 6l2.5 2.5L10 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        )}
-      </div>
-      <div>
-        <p className="text-sm text-text leading-tight">{label}</p>
-        {hint && <p className="text-xs text-text-muted mt-0.5">{hint}</p>}
-      </div>
-    </label>
-  );
 }
 
 export function AppFormModal({ mode, initial, onClose, onSubmit }: AppFormModalProps) {
@@ -178,89 +90,59 @@ export function AppFormModal({ mode, initial, onClose, onSubmit }: AppFormModalP
   }
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
+    <Modal onClickOutside={onClose}>
       <div className="bg-surface border border-border-strong rounded-xl w-full max-w-md shadow-xl max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border shrink-0">
           <h3 className="text-sm font-semibold text-text">
             {mode === "add" ? t("apps.form.title_add") : t("apps.form.title_edit")}
           </h3>
-          <button
-            onClick={onClose}
-            className="p-1 rounded text-text-muted hover:text-text transition-colors"
-            aria-label="close"
-          >
+          <Button variant="icon" onClick={onClose} aria-label="close">
             <X className="w-4 h-4" />
-          </button>
+          </Button>
         </div>
 
         {/* Scrollable body */}
         <form onSubmit={handleSubmit} className="flex flex-col min-h-0">
           <div className="flex flex-col gap-4 p-5 overflow-y-auto">
-
-            {/* ── Basic ── */}
             <SectionDivider title={t("apps.form.section_basic")} />
 
-            <Field label={t("apps.form.name")} id="app-form-name">
+            <FormField label={t("apps.form.name")} id="app-form-name">
               <TextInput id="app-form-name" value={form.name} onChange={(v) => patch("name", v)} />
-            </Field>
+            </FormField>
 
-            <Field label={t("apps.form.exe_path")} id="app-form-exe">
+            <FormField label={t("apps.form.exe_path")} id="app-form-exe">
               <TextInput id="app-form-exe" value={form.exe_path} onChange={(v) => patch("exe_path", v)} mono />
-            </Field>
+            </FormField>
 
-            <CheckRow
-              label={t("apps.form.enabled")}
-              checked={form.enabled}
-              onChange={(v) => patch("enabled", v)}
-            />
+            <Checkbox label={t("apps.form.enabled")} checked={form.enabled} onChange={(v) => patch("enabled", v)} />
+            <Checkbox label={t("apps.auto_stop")} checked={form.stop_with_iracing} onChange={(v) => patch("stop_with_iracing", v)} />
 
-            <CheckRow
-              label={t("apps.auto_stop")}
-              checked={form.stop_with_iracing}
-              onChange={(v) => patch("stop_with_iracing", v)}
-            />
-
-            {/* ── Startup ── */}
             <SectionDivider title={t("apps.form.section_startup")} />
 
-            <Field label={t("apps.form.startup_delay")}>
+            <FormField label={t("apps.form.startup_delay")}>
               <NumberInput value={form.startup_delay_secs} onChange={(v) => patch("startup_delay_secs", v)} step={0.5} />
-            </Field>
+            </FormField>
 
-            <Field label={t("apps.form.args")}>
+            <FormField label={t("apps.form.args")}>
               <TextInput value={form.args} onChange={(v) => patch("args", v)} mono />
-            </Field>
+            </FormField>
 
-            <Field label={t("apps.form.working_dir")}>
+            <FormField label={t("apps.form.working_dir")}>
               <TextInput value={form.working_dir} onChange={(v) => patch("working_dir", v)} mono />
-            </Field>
+            </FormField>
 
-            {/* ── Crash ── */}
             <SectionDivider title={t("apps.form.section_crash")} />
 
-            <CheckRow
-              label={t("apps.form.restart_on_crash")}
-              checked={form.restart_on_crash}
-              onChange={(v) => patch("restart_on_crash", v)}
-            />
+            <Checkbox label={t("apps.form.restart_on_crash")} checked={form.restart_on_crash} onChange={(v) => patch("restart_on_crash", v)} />
 
             {form.restart_on_crash && (
-              <Field label={t("apps.form.max_retries")}>
-                <NumberInput
-                  value={form.max_restart_attempts}
-                  onChange={(v) => patch("max_restart_attempts", v)}
-                  min={1}
-                />
-              </Field>
+              <FormField label={t("apps.form.max_retries")}>
+                <NumberInput value={form.max_restart_attempts} onChange={(v) => patch("max_restart_attempts", v)} min={1} />
+              </FormField>
             )}
 
-            {/* ── Advanced (collapsible) ── */}
+            {/* Advanced (collapsible) */}
             <button
               type="button"
               onClick={() => setAdvancedOpen((o) => !o)}
@@ -272,59 +154,40 @@ export function AppFormModal({ mode, initial, onClose, onSubmit }: AppFormModalP
 
             {advancedOpen && (
               <div className="flex flex-col gap-4 pl-3 border-l border-border">
-                <Field label={t("apps.form.track_process_name")} hint={t("apps.form.track_process_name_hint")}>
+                <FormField label={t("apps.form.track_process_name")} hint={t("apps.form.track_process_name_hint")}>
                   <TextInput value={form.track_process_name} onChange={(v) => patch("track_process_name", v)} mono />
-                </Field>
-
-                <CheckRow
-                  label={t("apps.form.force_kill")}
-                  hint={t("apps.form.force_kill_hint")}
-                  checked={form.force_kill_on_stop}
-                  onChange={(v) => patch("force_kill_on_stop", v)}
-                />
-
-                <CheckRow
-                  label={t("apps.form.kill_tree")}
-                  hint={t("apps.form.kill_tree_hint")}
-                  checked={form.kill_process_tree}
-                  onChange={(v) => patch("kill_process_tree", v)}
-                />
+                </FormField>
+                <Checkbox label={t("apps.form.force_kill")} hint={t("apps.form.force_kill_hint")} checked={form.force_kill_on_stop} onChange={(v) => patch("force_kill_on_stop", v)} />
+                <Checkbox label={t("apps.form.kill_tree")} hint={t("apps.form.kill_tree_hint")} checked={form.kill_process_tree} onChange={(v) => patch("kill_process_tree", v)} />
               </div>
             )}
           </div>
 
           {/* Footer */}
           <div className="flex flex-col gap-2 px-5 py-4 border-t border-border shrink-0">
-            {error && (
-              <p className="text-xs text-danger">{error}</p>
-            )}
+            {error && <p className="text-xs text-danger">{error}</p>}
             <div className="flex justify-end gap-2">
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 onClick={onClose}
                 disabled={saving || saved}
-                className="text-sm px-3 py-1.5 rounded-md border border-border-strong text-text-muted hover:text-text transition-colors disabled:opacity-50"
               >
                 {t("apps.form.cancel")}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="submit"
+                variant={saved ? "success" : "accent"}
                 disabled={saving || saved || !form.name.trim() || !form.exe_path.trim()}
-                className={cn(
-                  "flex items-center gap-1.5 text-sm font-semibold px-3 py-1.5 rounded-md border transition-colors disabled:opacity-50",
-                  saved
-                    ? "bg-success-solid text-on-success border-success-solid"
-                    : "bg-accent-solid hover:bg-accent-solid-hover text-on-accent border-accent-solid",
-                )}
               >
                 {saved ? (
                   <><Check className="w-3 h-3" />{t("apps.form.saved")}</>
                 ) : saving ? "…" : t("apps.form.save")}
-              </button>
+              </Button>
             </div>
           </div>
         </form>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,5 +1,7 @@
 import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/Button";
+import { Modal } from "@/components/ui/Modal";
 
 interface ConfirmDialogProps {
   title: string;
@@ -9,51 +11,26 @@ interface ConfirmDialogProps {
   onCancel: () => void;
 }
 
-export function ConfirmDialog({
-  title,
-  message,
-  confirmLabel,
-  onConfirm,
-  onCancel,
-}: ConfirmDialogProps) {
+export function ConfirmDialog({ title, message, confirmLabel, onConfirm, onCancel }: ConfirmDialogProps) {
   const { t } = useTranslation();
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
-    >
+    <Modal onClickOutside={onCancel}>
       <div className="bg-surface border border-border-strong rounded-xl w-full max-w-sm p-5 shadow-xl">
         <div className="flex items-center justify-between mb-3">
           <h3 className="text-sm font-semibold text-text">{title}</h3>
-          <button
-            onClick={onCancel}
-            className="p-1 rounded text-text-muted hover:text-text transition-colors"
-            aria-label={t("common.cancel")}
-          >
+          <Button variant="icon" onClick={onCancel} aria-label={t("common.cancel")}>
             <X className="w-4 h-4" />
-          </button>
+          </Button>
         </div>
 
         <p className="text-sm text-text-secondary mb-5">{message}</p>
 
         <div className="flex justify-end gap-2">
-          <button
-            onClick={onCancel}
-            className="text-sm px-3 py-1.5 rounded-md border border-border-strong text-text-muted hover:text-text transition-colors"
-          >
-            {t("common.cancel")}
-          </button>
-          <button
-            onClick={onConfirm}
-            className="text-sm font-semibold px-3 py-1.5 rounded-md bg-danger-solid text-on-danger border border-danger-solid hover:bg-danger-solid-hover transition-colors"
-          >
-            {confirmLabel}
-          </button>
+          <Button variant="ghost" onClick={onCancel}>{t("common.cancel")}</Button>
+          <Button variant="danger" onClick={onConfirm}>{confirmLabel}</Button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,8 +1,8 @@
 import { Globe, Check, ChevronDown } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LANGUAGES, setLanguage, type Language } from "@/i18n";
 import { cn } from "@/lib/cn";
+import { Dropdown } from "@/components/ui/Dropdown";
 
 const LABELS: Record<Language, string> = {
   "pt-BR": "Português (BR)",
@@ -21,48 +21,32 @@ interface LanguageSelectorProps {
 export function LanguageSelector({ variant = "default" }: LanguageSelectorProps) {
   const { i18n } = useTranslation();
   const current = i18n.language as Language;
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    function handler(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    }
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
 
   return (
-    <div ref={ref} className="relative">
-      <button
-        onClick={() => setOpen((o) => !o)}
-        className="flex items-center gap-1 text-text-muted hover:text-text-secondary transition-colors"
-      >
-        <Globe className={cn("shrink-0", variant === "compact" ? "w-3 h-3" : "w-3.5 h-3.5")} />
-        <span className="text-xs">{variant === "compact" ? SHORT[current] : LABELS[current]}</span>
-        <ChevronDown className={cn("w-3 h-3 transition-transform", open && "rotate-180")} />
-      </button>
-
-      {open && (
-        <div className="absolute right-0 top-full mt-1.5 z-50 bg-elevated border border-border-strong rounded-lg shadow-xl min-w-[152px] py-1 overflow-hidden">
-          {LANGUAGES.map((lang) => (
-            <button
-              key={lang}
-              onClick={() => { setLanguage(lang); setOpen(false); }}
-              className={cn(
-                "w-full flex items-center justify-between px-3 py-1.5 text-xs text-left transition-colors",
-                lang === current
-                  ? "text-accent bg-accent/10"
-                  : "text-text-muted hover:text-text hover:bg-surface",
-              )}
-            >
-              {LABELS[lang]}
-              {lang === current && <Check className="w-3 h-3 shrink-0" />}
-            </button>
-          ))}
-        </div>
+    <Dropdown
+      trigger={(open) => (
+        <button
+          className="flex items-center gap-1 text-text-muted hover:text-text-secondary transition-colors"
+        >
+          <Globe className={cn("shrink-0", variant === "compact" ? "w-3 h-3" : "w-3.5 h-3.5")} />
+          <span className="text-xs">{variant === "compact" ? SHORT[current] : LABELS[current]}</span>
+          <ChevronDown className={cn("w-3 h-3 transition-transform", open && "rotate-180")} />
+        </button>
       )}
-    </div>
+    >
+      {LANGUAGES.map((lang) => (
+        <button
+          key={lang}
+          onClick={() => setLanguage(lang)}
+          className={cn(
+            "w-full flex items-center justify-between px-3 py-1.5 text-xs text-left transition-colors",
+            lang === current ? "text-accent bg-accent/10" : "text-text-muted hover:text-text hover:bg-surface",
+          )}
+        >
+          {LABELS[lang]}
+          {lang === current && <Check className="w-3 h-3 shrink-0" />}
+        </button>
+      ))}
+    </Dropdown>
   );
 }

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,8 +1,9 @@
 import { Check, ChevronDown, Palette } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { THEMES, getTheme, setTheme, type Theme } from "@/theme";
 import { cn } from "@/lib/cn";
+import { Dropdown } from "@/components/ui/Dropdown";
 
 interface ThemeSelectorProps {
   variant?: "default" | "compact";
@@ -16,61 +17,44 @@ const SHORT: Record<Theme, string> = {
 export function ThemeSelector({ variant = "default" }: ThemeSelectorProps) {
   const { t } = useTranslation();
   const [current, setCurrent] = useState<Theme>(() => getTheme());
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     function handleThemeChange(e: Event) {
       setCurrent((e as CustomEvent<Theme>).detail);
     }
-
     window.addEventListener("pitlane:theme-change", handleThemeChange);
     return () => window.removeEventListener("pitlane:theme-change", handleThemeChange);
   }, []);
 
-  useEffect(() => {
-    if (!open) return;
-    function handler(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    }
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
-
   return (
-    <div ref={ref} className="relative">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        className="flex items-center gap-1 text-text-muted hover:text-text-secondary transition-colors"
-      >
-        <Palette className={cn("shrink-0", variant === "compact" ? "w-3 h-3" : "w-3.5 h-3.5")} />
-        <span className="text-xs">
-          {variant === "compact" ? SHORT[current] : t(`settings.themes.${current}`)}
-        </span>
-        <ChevronDown className={cn("w-3 h-3 transition-transform", open && "rotate-180")} />
-      </button>
-
-      {open && (
-        <div className="absolute right-0 top-full mt-1.5 z-50 bg-elevated border border-border-strong rounded-lg shadow-xl min-w-[168px] py-1 overflow-hidden">
-          {THEMES.map((theme) => (
-            <button
-              key={theme}
-              type="button"
-              onClick={() => { setTheme(theme); setOpen(false); }}
-              className={cn(
-                "w-full flex items-center justify-between gap-3 px-3 py-1.5 text-xs text-left transition-colors",
-                theme === current
-                  ? "text-accent bg-accent/10"
-                  : "text-text-muted hover:text-text hover:bg-surface",
-              )}
-            >
-              {t(`settings.themes.${theme}`)}
-              {theme === current && <Check className="w-3 h-3 shrink-0" />}
-            </button>
-          ))}
-        </div>
+    <Dropdown
+      trigger={(open) => (
+        <button
+          type="button"
+          className="flex items-center gap-1 text-text-muted hover:text-text-secondary transition-colors"
+        >
+          <Palette className={cn("shrink-0", variant === "compact" ? "w-3 h-3" : "w-3.5 h-3.5")} />
+          <span className="text-xs">
+            {variant === "compact" ? SHORT[current] : t(`settings.themes.${current}`)}
+          </span>
+          <ChevronDown className={cn("w-3 h-3 transition-transform", open && "rotate-180")} />
+        </button>
       )}
-    </div>
+    >
+      {THEMES.map((theme) => (
+        <button
+          key={theme}
+          type="button"
+          onClick={() => setTheme(theme)}
+          className={cn(
+            "w-full flex items-center justify-between gap-3 px-3 py-1.5 text-xs text-left transition-colors",
+            theme === current ? "text-accent bg-accent/10" : "text-text-muted hover:text-text hover:bg-surface",
+          )}
+        >
+          {t(`settings.themes.${theme}`)}
+          {theme === current && <Check className="w-3 h-3 shrink-0" />}
+        </button>
+      ))}
+    </Dropdown>
   );
 }

--- a/src/components/layout/FormField.tsx
+++ b/src/components/layout/FormField.tsx
@@ -1,0 +1,16 @@
+interface FormFieldProps {
+  label: string;
+  hint?: string;
+  id?: string;
+  children: React.ReactNode;
+}
+
+export function FormField({ label, hint, id, children }: FormFieldProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={id} className="text-xs text-text-muted">{label}</label>
+      {children}
+      {hint && <p className="text-xs text-text-muted">{hint}</p>}
+    </div>
+  );
+}

--- a/src/components/layout/ScreenHeader.tsx
+++ b/src/components/layout/ScreenHeader.tsx
@@ -1,0 +1,13 @@
+interface ScreenHeaderProps {
+  title: string;
+  action?: React.ReactNode;
+}
+
+export function ScreenHeader({ title, action }: ScreenHeaderProps) {
+  return (
+    <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
+      <h2 className="text-sm font-semibold text-text">{title}</h2>
+      {action}
+    </div>
+  );
+}

--- a/src/components/screens/AppsScreen.tsx
+++ b/src/components/screens/AppsScreen.tsx
@@ -1,232 +1,14 @@
 import { useEffect, useState } from "react";
-import { Activity, AlertTriangle, Ban, Clock3, LayoutList, Pencil, Plus, Square, Play, Trash2 } from "lucide-react";
+import { LayoutList, Plus } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import type { TFunction } from "i18next";
-import { cn } from "@/lib/cn";
-import { api, type AppStatus, type ManagedApp, type NewApp, type Profile } from "@/lib/api";
+import { api, type ManagedApp, type NewApp, type Profile } from "@/lib/api";
 import { useAppStatuses } from "@/hooks/useAppStatuses";
+import { Button } from "@/components/ui/Button";
+import { Toggle } from "@/components/ui/Toggle";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { AppCard } from "@/components/AppCard";
 import { AppFormModal } from "@/components/AppFormModal";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
-
-// ── Status helpers ────────────────────────────────────────────────────────────
-
-function StatusBadge({ status, enabled, t }: { status: AppStatus | undefined; enabled: boolean; t: TFunction }) {
-  const type = status?.state.type ?? "idle";
-
-  if (!enabled) {
-    return (
-      <span className="inline-flex items-center gap-1.5 rounded border border-border-strong bg-elevated px-1.5 py-0.5 text-[11px] font-medium text-text-muted">
-        <Ban className="h-3.5 w-3.5 shrink-0 stroke-[2.5]" />
-        {t("apps.status.disabled")}
-      </span>
-    );
-  }
-
-  if (type === "running") {
-    return (
-      <span className="inline-flex items-center gap-1.5 rounded border border-success bg-elevated px-1.5 py-0.5 text-[11px] font-medium text-success">
-        <Activity className="h-3.5 w-3.5 shrink-0 stroke-[2.5]" />
-        {t("apps.status.running")}
-      </span>
-    );
-  }
-  if (type === "crashed") {
-    return (
-      <span className="inline-flex items-center gap-1 rounded border border-warning bg-elevated px-1.5 py-0.5 text-[11px] font-medium text-warning">
-        <AlertTriangle className="h-3.5 w-3.5 shrink-0 stroke-[2.5]" />
-        {t("apps.status.crashed")}
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex items-center gap-1.5 rounded border border-border-strong bg-elevated px-1.5 py-0.5 text-[11px] font-medium text-text-secondary">
-      <Clock3 className="h-3.5 w-3.5 shrink-0 stroke-[2.5]" />
-      {t("apps.status.idle")}
-    </span>
-  );
-}
-
-function statusDetail(status: AppStatus | undefined): string | null {
-  if (status?.state.type !== "running") return null;
-  const pid = (status.state as { pid: number }).pid;
-  return `PID ${pid}`;
-}
-
-// ── App letter-avatar ─────────────────────────────────────────────────────────
-
-const AVATAR_COLORS = [
-  "bg-accent/20 text-accent",
-  "bg-success/20 text-success",
-  "bg-warning/20 text-warning",
-  "bg-danger/20 text-danger",
-];
-
-function AppAvatar({ name }: { name: string }) {
-  const idx = (name.charCodeAt(0) ?? 0) % AVATAR_COLORS.length;
-  return (
-    <div className={cn("w-8 h-8 rounded-lg flex items-center justify-center text-xs font-bold shrink-0 select-none", AVATAR_COLORS[idx])}>
-      {name[0]?.toUpperCase() ?? "?"}
-    </div>
-  );
-}
-
-// ── Toggle switch ─────────────────────────────────────────────────────────────
-
-function Toggle({
-  checked,
-  disabled = false,
-  onChange,
-  label,
-}: {
-  checked: boolean;
-  disabled?: boolean;
-  onChange: (v: boolean) => void;
-  label: string;
-}) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      aria-label={label}
-      disabled={disabled}
-      onClick={() => {
-        if (!disabled) onChange(!checked);
-      }}
-      className={cn(
-        "flex h-5 w-9 items-center rounded-full p-0.5 transition-colors shrink-0 disabled:cursor-not-allowed",
-        disabled
-          ? "bg-elevated border border-border"
-          : checked
-            ? "bg-accent-solid hover:bg-accent-solid-hover"
-            : "bg-elevated border border-accent-solid hover:bg-surface",
-      )}
-    >
-      <span className={cn(
-        "h-4 w-4 rounded-full transition-transform",
-        disabled
-          ? "translate-x-0 bg-text-disabled"
-          : checked
-            ? "translate-x-4 bg-on-accent"
-            : "translate-x-0 bg-accent-solid",
-      )} />
-    </button>
-  );
-}
-
-// ── App card ──────────────────────────────────────────────────────────────────
-
-interface AppCardProps {
-  app: ManagedApp;
-  status: AppStatus | undefined;
-  onStart: () => void;
-  onStop: () => void;
-  onEdit: () => void;
-  onDelete: () => void;
-  onToggleEnabled: (enabled: boolean) => void;
-  onToggleStopWithIracing: (stop: boolean) => void;
-}
-
-function AppCard({ app, status, onStart, onStop, onEdit, onDelete, onToggleEnabled, onToggleStopWithIracing }: AppCardProps) {
-  const { t } = useTranslation();
-  const running = status?.state.type === "running";
-  const detail = statusDetail(status);
-  const appDisabled = !app.enabled;
-
-  return (
-    <li
-      data-testid="app-card"
-      className={cn(
-        "flex flex-col rounded-lg border bg-surface border-border-strong transition-colors",
-        !app.enabled && "bg-surface-disabled border-border",
-      )}
-    >
-      {/* Row 1: icon / name / status / actions */}
-      <div className="flex items-center gap-3 px-3 py-2.5">
-        <div className={cn(appDisabled && "opacity-55")}>
-          <AppAvatar name={app.name} />
-        </div>
-
-        <div className="flex-1 min-w-0">
-          <div className="flex flex-col gap-1">
-            <span className={cn("text-sm font-medium text-text truncate", appDisabled && "opacity-60")}>
-              {app.name}
-            </span>
-            <div className="flex items-center gap-2 min-h-5">
-              <StatusBadge status={status} enabled={app.enabled} t={t} />
-              {detail && (
-                <span className="text-xs text-text-muted truncate font-mono" title={detail}>
-                  {detail}
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-1 shrink-0">
-          {running ? (
-            <button
-              title={t("apps.stop")}
-              onClick={onStop}
-              className="flex items-center gap-1 text-sm font-semibold px-2.5 py-1.5 rounded-md bg-danger-solid text-on-danger border border-danger-solid hover:bg-danger-solid-hover transition-colors"
-            >
-              <Square className="w-3.5 h-3.5 fill-current stroke-[2.5]" />
-              {t("apps.stop")}
-            </button>
-          ) : (
-            <button
-              title={t("apps.start")}
-              onClick={onStart}
-              className="flex items-center gap-1 text-sm font-semibold px-2.5 py-1.5 rounded-md bg-success-solid text-on-success border border-success-solid hover:bg-success-solid-hover transition-colors"
-            >
-              <Play className="w-3.5 h-3.5 fill-current stroke-[2.5]" />
-              {t("apps.start")}
-            </button>
-          )}
-
-          <button
-            title={t("apps.edit")}
-            onClick={onEdit}
-            className="p-1.5 rounded text-text-secondary hover:text-text hover:bg-elevated transition-colors"
-          >
-            <Pencil className="w-4 h-4 stroke-[2.5]" />
-          </button>
-
-          <button
-            title={t("apps.delete")}
-            onClick={onDelete}
-            className="p-1.5 rounded text-danger hover:bg-danger/10 transition-colors"
-          >
-            <Trash2 className="w-4 h-4 stroke-[2.5]" />
-          </button>
-        </div>
-      </div>
-
-      {/* Row 2: auto-start / auto-stop toggles */}
-      <div className="flex items-center justify-between px-3 pb-2.5 -mt-0.5 gap-4">
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-text-secondary">{t("apps.auto_start")}</span>
-          <Toggle
-            checked={app.enabled}
-            onChange={onToggleEnabled}
-            label={t("apps.auto_start")}
-          />
-        </div>
-        <div className={cn("flex items-center gap-2", appDisabled && "opacity-60")}>
-          <span className="text-xs text-text-muted">{t("apps.auto_stop")}</span>
-          <Toggle
-            checked={app.stop_with_iracing}
-            disabled={appDisabled}
-            onChange={onToggleStopWithIracing}
-            label={t("apps.auto_stop")}
-          />
-        </div>
-      </div>
-    </li>
-  );
-}
-
-// ── Screen ────────────────────────────────────────────────────────────────────
 
 type ModalState =
   | { type: "add" }
@@ -263,13 +45,9 @@ export function AppsScreen() {
   }
 
   async function handleFormSubmit(data: NewApp) {
-    if (modal?.type === "add") {
-      await api.addApp(data);
-    } else if (modal?.type === "edit") {
-      await api.updateApp(modal.app.id, data);
-    }
+    if (modal?.type === "add") await api.addApp(data);
+    else if (modal?.type === "edit") await api.updateApp(modal.app.id, data);
     await loadApps();
-    // modal closes itself after showing brief success state
   }
 
   async function handleDelete(app: ManagedApp) {
@@ -299,9 +77,7 @@ export function AppsScreen() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <div
-            className="flex items-center gap-2 rounded-md border border-border-strong bg-surface px-2.5 py-1.5"
-          >
+          <div className="flex items-center gap-2 rounded-md border border-border-strong bg-surface px-2.5 py-1.5">
             <span className="text-xs text-text-secondary">
               <span className="font-bold text-accent">{t("apps.auto_stop_label_emphasis")}</span>{" "}
               {t("apps.auto_stop_label_rest")}
@@ -312,52 +88,42 @@ export function AppsScreen() {
               label={t("apps.auto_stop_label")}
             />
           </div>
-          <button
-            onClick={() => setModal({ type: "add" })}
-            className="flex items-center gap-1.5 text-sm font-semibold px-3 py-1.5 rounded-md bg-accent-solid text-on-accent border border-accent-solid hover:bg-accent-solid-hover transition-colors"
-          >
+          <Button onClick={() => setModal({ type: "add" })}>
             <Plus className="w-4 h-4 stroke-[2.5]" />
             {t("apps.add")}
-          </button>
+          </Button>
         </div>
       </div>
 
       {/* App list */}
       {apps.length === 0 ? (
-        <div className="flex-1 flex flex-col items-center justify-center text-text-muted gap-3">
-          <LayoutList className="w-8 h-8" />
-          <div className="flex flex-col items-center gap-2">
-            <p className="text-sm">{t("apps.empty")}</p>
-            <button
-              onClick={() => setModal({ type: "add" })}
-              className="text-sm font-semibold px-3 py-1.5 rounded-md bg-accent-solid text-on-accent border border-accent-solid hover:bg-accent-solid-hover transition-colors"
-            >
+        <EmptyState
+          icon={LayoutList}
+          message={t("apps.empty")}
+          action={
+            <Button onClick={() => setModal({ type: "add" })}>
               {t("apps.add_first")}
-            </button>
-          </div>
-        </div>
+            </Button>
+          }
+        />
       ) : (
         <ul className="flex flex-col gap-2">
-          {apps.map((app) => {
-            const status = statuses.find((s) => s.app_id === app.id);
-            return (
-              <AppCard
-                key={app.id}
-                app={app}
-                status={status}
-                onStart={() => api.forceLaunchApp(app.id)}
-                onStop={() => api.forceKillApp(app.id)}
-                onEdit={() => setModal({ type: "edit", app })}
-                onDelete={() => setConfirmDelete(app)}
-                onToggleEnabled={(enabled) => handleToggleEnabled(app, enabled)}
-                onToggleStopWithIracing={(stop) => handleToggleStopWithIracing(app, stop)}
-              />
-            );
-          })}
+          {apps.map((app) => (
+            <AppCard
+              key={app.id}
+              app={app}
+              status={statuses.find((s) => s.app_id === app.id)}
+              onStart={() => api.forceLaunchApp(app.id)}
+              onStop={() => api.forceKillApp(app.id)}
+              onEdit={() => setModal({ type: "edit", app })}
+              onDelete={() => setConfirmDelete(app)}
+              onToggleEnabled={(enabled) => handleToggleEnabled(app, enabled)}
+              onToggleStopWithIracing={(stop) => handleToggleStopWithIracing(app, stop)}
+            />
+          ))}
         </ul>
       )}
 
-      {/* Add / Edit modal */}
       {modal && (
         <AppFormModal
           mode={modal.type}
@@ -367,7 +133,6 @@ export function AppsScreen() {
         />
       )}
 
-      {/* Delete confirmation */}
       {confirmDelete && (
         <ConfirmDialog
           title={t("apps.delete_confirm_title")}

--- a/src/components/screens/HistoryScreen.tsx
+++ b/src/components/screens/HistoryScreen.tsx
@@ -1,5 +1,8 @@
 import { Clock } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { ScreenHeader } from "@/components/layout/ScreenHeader";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Tag } from "@/components/ui/Badge";
 
 interface Session {
   id: string;
@@ -26,8 +29,7 @@ const MOCK_SESSIONS: Session[] = [
 function formatDuration(seconds: number) {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
-  if (h > 0) return `${h}h ${m}min`;
-  return `${m}min`;
+  return h > 0 ? `${h}h ${m}min` : `${m}min`;
 }
 
 function formatDate(iso: string, locale: string) {
@@ -41,22 +43,19 @@ export function HistoryScreen() {
   const { t, i18n } = useTranslation();
 
   if (MOCK_SESSIONS.length === 0) {
-    return (
-      <div className="flex-1 flex flex-col items-center justify-center text-text-disabled gap-2 h-full">
-        <Clock className="w-8 h-8" />
-        <p className="text-sm">{t("history.empty")}</p>
-      </div>
-    );
+    return <EmptyState icon={Clock} message={t("history.empty")} />;
   }
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
-        <h2 className="text-sm font-semibold text-text">{t("history.title")}</h2>
-        <button className="text-xs text-text-muted hover:text-text-secondary transition-colors">
-          {t("history.clear")}
-        </button>
-      </div>
+      <ScreenHeader
+        title={t("history.title")}
+        action={
+          <button className="text-xs text-text-muted hover:text-text-secondary transition-colors">
+            {t("history.clear")}
+          </button>
+        }
+      />
 
       <ul className="flex-1 overflow-y-auto p-3 flex flex-col gap-2">
         {MOCK_SESSIONS.map((s) => (
@@ -69,9 +68,7 @@ export function HistoryScreen() {
             </div>
             <div className="flex items-center gap-2 mt-1.5 flex-wrap">
               {s.appsLaunched.map((name) => (
-                <span key={name} className="text-xs px-1.5 py-0.5 rounded bg-elevated text-text-secondary">
-                  {name}
-                </span>
+                <Tag key={name}>{name}</Tag>
               ))}
             </div>
           </li>

--- a/src/components/screens/LogScreen.tsx
+++ b/src/components/screens/LogScreen.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useRef } from "react";
+import { ScrollText } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
 import { useLog } from "@/hooks/useLog";
 import type { LogKind } from "@/lib/api";
+import { ScreenHeader } from "@/components/layout/ScreenHeader";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 const kindStyle: Record<LogKind, string> = {
   launch:        "text-success",
@@ -20,10 +23,9 @@ const kindLabel: Record<LogKind, string> = {
 
 function formatTime(ms: number): string {
   const d = new Date(ms);
-  const h = d.getHours().toString().padStart(2, "0");
-  const m = d.getMinutes().toString().padStart(2, "0");
-  const s = d.getSeconds().toString().padStart(2, "0");
-  return `${h}:${m}:${s}`;
+  return [d.getHours(), d.getMinutes(), d.getSeconds()]
+    .map((n) => n.toString().padStart(2, "0"))
+    .join(":");
 }
 
 export function LogScreen() {
@@ -37,13 +39,11 @@ export function LogScreen() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
-        <h2 className="text-sm font-semibold text-text">{t("log.title")}</h2>
-      </div>
+      <ScreenHeader title={t("log.title")} />
 
       <div className="flex-1 overflow-y-auto p-3 font-mono text-xs flex flex-col gap-0.5">
         {entries.length === 0 ? (
-          <p className="text-text-disabled text-center mt-8">{t("log.empty")}</p>
+          <EmptyState icon={ScrollText} message={t("log.empty")} />
         ) : (
           entries.map((entry) => (
             <div

--- a/src/components/screens/SettingsScreen.tsx
+++ b/src/components/screens/SettingsScreen.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { cn } from "@/lib/cn";
+import { api, type Settings, type TriggerMode } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { Toggle } from "@/components/ui/Toggle";
+import { NumberInput } from "@/components/ui/Input";
+import { SectionDivider } from "@/components/ui/SectionDivider";
+import { FormField } from "@/components/layout/FormField";
 import { LanguageSelector } from "@/components/LanguageSelector";
 import { ThemeSelector } from "@/components/ThemeSelector";
-import { api, type Settings, type TriggerMode } from "@/lib/api";
 
 const DEFAULT_SETTINGS: Settings = {
   poll_interval_secs: 1,
@@ -17,9 +21,7 @@ export function SettingsScreen() {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [saving, setSaving] = useState(false);
 
-  useEffect(() => {
-    api.getSettings().then(setSettings);
-  }, []);
+  useEffect(() => { api.getSettings().then(setSettings); }, []);
 
   function patch<K extends keyof Settings>(key: K, value: Settings[K]) {
     setSettings((prev) => ({ ...prev, [key]: value }));
@@ -27,11 +29,8 @@ export function SettingsScreen() {
 
   async function handleSave() {
     setSaving(true);
-    try {
-      await api.saveSettings(settings);
-    } finally {
-      setSaving(false);
-    }
+    try { await api.saveSettings(settings); }
+    finally { setSaving(false); }
   }
 
   return (
@@ -39,24 +38,17 @@ export function SettingsScreen() {
       <h2 className="text-sm font-semibold text-text">{t("settings.title")}</h2>
 
       <section className="flex flex-col gap-3">
-        <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
-          {t("settings.sections.monitoring")}
-        </h3>
+        <SectionDivider title={t("settings.sections.monitoring")} />
 
-        <div className="flex flex-col gap-1">
-          <label className="text-xs font-medium text-text-secondary">
-            {t("settings.poll_interval_label")}
-          </label>
-          <input
-            type="number"
+        <FormField label={t("settings.poll_interval_label")}>
+          <NumberInput
             value={settings.poll_interval_secs}
-            onChange={(e) => patch("poll_interval_secs", parseFloat(e.target.value) || 1)}
+            onChange={(v) => patch("poll_interval_secs", v || 1)}
             min={0.25}
             step={0.25}
-            className="w-24 px-2 py-1.5 text-sm bg-surface border border-border-strong rounded text-text font-mono
-                       focus:outline-none focus:border-accent/60 focus:ring-1 focus:ring-accent/20 transition-colors"
+            className="w-24"
           />
-        </div>
+        </FormField>
 
         <div className="flex flex-col gap-1.5">
           <label className="text-xs font-medium text-text-secondary">
@@ -82,9 +74,7 @@ export function SettingsScreen() {
       </section>
 
       <section className="flex flex-col gap-3">
-        <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
-          {t("settings.sections.system")}
-        </h3>
+        <SectionDivider title={t("settings.sections.system")} />
 
         <ToggleRow
           label={t("settings.autostart_label")}
@@ -98,31 +88,28 @@ export function SettingsScreen() {
           enabled={settings.notifications_enabled}
           onChange={(v) => patch("notifications_enabled", v)}
         />
-
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-xs font-medium text-text-secondary">{t("settings.language_label")}</p>
-          </div>
+        <SettingRow label={t("settings.language_label")}>
           <LanguageSelector variant="default" />
-        </div>
-
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-xs font-medium text-text-secondary">{t("settings.theme_label")}</p>
-          </div>
+        </SettingRow>
+        <SettingRow label={t("settings.theme_label")}>
           <ThemeSelector variant="default" />
-        </div>
+        </SettingRow>
       </section>
 
       <div className="flex justify-end pt-2">
-        <button
-          onClick={handleSave}
-          disabled={saving}
-          className="px-4 py-1.5 text-sm font-semibold rounded bg-accent-solid hover:bg-accent-solid-hover text-on-accent border border-accent-solid transition-colors disabled:opacity-50"
-        >
+        <Button onClick={handleSave} disabled={saving}>
           {saving ? "…" : t("settings.save")}
-        </button>
+        </Button>
       </div>
+    </div>
+  );
+}
+
+function SettingRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between">
+      <p className="text-xs font-medium text-text-secondary">{label}</p>
+      {children}
     </div>
   );
 }
@@ -144,22 +131,7 @@ function ToggleRow({
         <p className="text-xs font-medium text-text-secondary">{label}</p>
         <p className="text-xs text-text-muted">{description}</p>
       </div>
-      <button
-        role="switch"
-        aria-checked={enabled}
-        onClick={() => onChange(!enabled)}
-        className={cn(
-          "flex h-5 w-10 items-center rounded-full p-0.5 transition-colors shrink-0",
-          enabled ? "bg-accent-solid hover:bg-accent-solid-hover" : "bg-elevated border border-accent-solid hover:bg-surface",
-        )}
-      >
-        <span
-          className={cn(
-            "h-4 w-4 rounded-full transition-transform",
-            enabled ? "translate-x-5 bg-on-accent" : "translate-x-0 bg-accent-solid",
-          )}
-        />
-      </button>
+      <Toggle checked={enabled} onChange={onChange} label={label} />
     </div>
   );
 }

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -28,7 +28,7 @@ export function StatusBadge({ status, enabled, label }: StatusBadgeProps) {
 
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded border bg-elevated px-1.5 py-0.5 text-[11px] font-medium ${colorClass}`}
+      className={`inline-flex items-center gap-1.5 rounded border bg-elevated px-1.5 py-0.5 text-xs font-medium ${colorClass}`}
     >
       <Icon className="h-3.5 w-3.5 shrink-0 stroke-[2.5]" />
       {label}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,49 @@
+import { Activity, AlertTriangle, Ban, Clock3 } from "lucide-react";
+import type { AppStatus } from "@/lib/api";
+
+type StatusVariant = "running" | "crashed" | "idle" | "disabled";
+
+const CONFIG: Record<StatusVariant, {
+  icon: React.ElementType;
+  colorClass: string;
+}> = {
+  running:  { icon: Activity,       colorClass: "border-success text-success" },
+  crashed:  { icon: AlertTriangle,  colorClass: "border-warning text-warning" },
+  idle:     { icon: Clock3,         colorClass: "border-border-strong text-text-secondary" },
+  disabled: { icon: Ban,            colorClass: "border-border-strong text-text-muted" },
+};
+
+interface StatusBadgeProps {
+  status: AppStatus | undefined;
+  enabled: boolean;
+  label: string;
+}
+
+export function StatusBadge({ status, enabled, label }: StatusBadgeProps) {
+  const variant: StatusVariant = !enabled
+    ? "disabled"
+    : (status?.state.type ?? "idle") as StatusVariant;
+
+  const { icon: Icon, colorClass } = CONFIG[variant];
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded border bg-elevated px-1.5 py-0.5 text-[11px] font-medium ${colorClass}`}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0 stroke-[2.5]" />
+      {label}
+    </span>
+  );
+}
+
+interface TagProps {
+  children: React.ReactNode;
+}
+
+export function Tag({ children }: TagProps) {
+  return (
+    <span className="text-xs px-1.5 py-0.5 rounded bg-elevated text-text-secondary">
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,37 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/cn";
+
+const button = cva(
+  "inline-flex items-center justify-center gap-1.5 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
+  {
+    variants: {
+      variant: {
+        accent:  "rounded-md border border-accent-solid bg-accent-solid text-on-accent hover:bg-accent-solid-hover",
+        success: "rounded-md border border-success-solid bg-success-solid text-on-success hover:bg-success-solid-hover",
+        danger:  "rounded-md border border-danger-solid bg-danger-solid text-on-danger hover:bg-danger-solid-hover",
+        ghost:   "rounded-md border border-border-strong text-text-muted hover:text-text hover:bg-elevated",
+        icon:    "rounded p-1.5 text-text-secondary hover:text-text hover:bg-elevated",
+      },
+      size: {
+        sm: "px-2.5 py-1 text-xs",
+        md: "px-3 py-1.5 text-sm",
+      },
+    },
+    defaultVariants: {
+      variant: "accent",
+      size: "md",
+    },
+    compoundVariants: [
+      { variant: "icon", size: "sm", class: "px-1 py-1" },
+      { variant: "icon", size: "md", class: "p-1.5" },
+    ],
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof button> {}
+
+export function Button({ variant, size, className, ...props }: ButtonProps) {
+  return <button className={cn(button({ variant, size }), className)} {...props} />;
+}

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -1,0 +1,36 @@
+import { Check } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+interface CheckboxProps {
+  label: string;
+  hint?: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}
+
+export function Checkbox({ label, hint, checked, onChange }: CheckboxProps) {
+  return (
+    <label className="flex items-start gap-2.5 cursor-pointer group">
+      <div
+        className={cn(
+          "mt-0.5 w-4 h-4 rounded border shrink-0 flex items-center justify-center transition-colors",
+          checked
+            ? "border-accent-solid bg-accent-solid"
+            : "border-border-strong bg-elevated group-hover:border-accent/50",
+        )}
+      >
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          className="sr-only"
+        />
+        {checked && <Check className="w-3 h-3 text-on-accent stroke-[2.5]" />}
+      </div>
+      <div>
+        <p className="text-sm text-text leading-tight">{label}</p>
+        {hint && <p className="text-xs text-text-muted mt-0.5">{hint}</p>}
+      </div>
+    </label>
+  );
+}

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState } from "react";
+
+interface DropdownProps {
+  trigger: (open: boolean) => React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function Dropdown({ trigger, children }: DropdownProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <div onClick={() => setOpen((o) => !o)}>
+        {trigger(open)}
+      </div>
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-1.5 z-50 bg-elevated border border-border-strong rounded-lg shadow-xl min-w-[152px] py-1 overflow-hidden"
+          onClick={() => setOpen(false)}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,19 @@
+import type { LucideIcon } from "lucide-react";
+
+interface EmptyStateProps {
+  icon: LucideIcon;
+  message: string;
+  action?: React.ReactNode;
+}
+
+export function EmptyState({ icon: Icon, message, action }: EmptyStateProps) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center text-text-muted gap-3 h-full">
+      <Icon className="w-8 h-8" />
+      <div className="flex flex-col items-center gap-2">
+        <p className="text-sm">{message}</p>
+        {action}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@/lib/cn";
+
+const inputBase =
+  "text-sm bg-elevated border border-border-strong rounded-md px-3 py-1.5 text-text outline-none focus:border-accent placeholder:text-text-disabled transition-colors";
+
+interface TextInputProps {
+  id?: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  mono?: boolean;
+}
+
+export function TextInput({ id, value, onChange, placeholder, mono = false }: TextInputProps) {
+  return (
+    <input
+      id={id}
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      className={cn(inputBase, mono && "font-mono text-xs")}
+    />
+  );
+}
+
+interface NumberInputProps {
+  id?: string;
+  value: number;
+  onChange: (v: number) => void;
+  min?: number;
+  step?: number;
+  className?: string;
+}
+
+export function NumberInput({ id, value, onChange, min = 0, step = 1, className }: NumberInputProps) {
+  return (
+    <input
+      id={id}
+      type="number"
+      value={value}
+      onChange={(e) => onChange(Number(e.target.value))}
+      min={min}
+      step={step}
+      className={cn(inputBase, "w-28", className)}
+    />
+  );
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,17 @@
+interface ModalProps {
+  children: React.ReactNode;
+  onClickOutside: () => void;
+}
+
+export function Modal({ children, onClickOutside }: ModalProps) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onClickOutside(); }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/SectionDivider.tsx
+++ b/src/components/ui/SectionDivider.tsx
@@ -1,0 +1,14 @@
+interface SectionDividerProps {
+  title: string;
+}
+
+export function SectionDivider({ title }: SectionDividerProps) {
+  return (
+    <div className="flex items-center gap-2 pt-1">
+      <span className="text-xs font-semibold uppercase tracking-widest text-text-muted">
+        {title}
+      </span>
+      <div className="flex-1 h-px bg-border" />
+    </div>
+  );
+}

--- a/src/components/ui/Toggle.tsx
+++ b/src/components/ui/Toggle.tsx
@@ -1,0 +1,40 @@
+import { cn } from "@/lib/cn";
+
+interface ToggleProps {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+  disabled?: boolean;
+}
+
+export function Toggle({ checked, onChange, label, disabled = false }: ToggleProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => { if (!disabled) onChange(!checked); }}
+      className={cn(
+        "flex h-5 w-9 items-center rounded-full p-0.5 transition-colors shrink-0 disabled:cursor-not-allowed",
+        disabled
+          ? "border border-border bg-elevated"
+          : checked
+            ? "bg-accent-solid hover:bg-accent-solid-hover"
+            : "border border-accent-solid bg-elevated hover:bg-surface",
+      )}
+    >
+      <span
+        className={cn(
+          "h-4 w-4 rounded-full transition-transform",
+          disabled
+            ? "translate-x-0 bg-text-disabled"
+            : checked
+              ? "translate-x-4 bg-on-accent"
+              : "translate-x-0 bg-accent-solid",
+        )}
+      />
+    </button>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -71,40 +71,40 @@
 
 html[data-theme="pitlane-nebula"] {
   /* --- Primitive ramps: Pitlane Nebula --- */
-  --color-aqua-100:  #eefdfb;
-  --color-aqua-200:  #c4e7e3;
-  --color-aqua-300:  #93c7c1;
-  --color-aqua-400:  #6aa09b;
-  --color-aqua-500:  #4a7773;
-  --color-aqua-600:  #235c5a;
-  --color-aqua-700:  #174343;
-  --color-aqua-800:  #103030;
-  --color-aqua-900:  #0b2020;
-  --color-aqua-1000: #061313;
+  --color-aqua-100:  #effefb;
+  --color-aqua-200:  #c7e9e5;
+  --color-aqua-300:  #95c6c1;
+  --color-aqua-400:  #6b9f9a;
+  --color-aqua-500:  #4c7671;
+  --color-aqua-600:  #2a5e5b;
+  --color-aqua-700:  #183f3d;
+  --color-aqua-800:  #0e2c2b;
+  --color-aqua-900:  #081818;
+  --color-aqua-1000: #041010;
 
-  --color-purple-100:  #f1edff;
-  --color-purple-200:  #d8ccff;
-  --color-purple-300:  #b8a2ff;
-  --color-purple-400:  #9c82f2;
+  --color-purple-100:  #f3efff;
+  --color-purple-200:  #dfd2ff;
+  --color-purple-300:  #bfa4ff;
+  --color-purple-400:  #9d82f2;
   --color-purple-500:  #8168d8;
-  --color-purple-600:  #6b55bd;
-  --color-purple-700:  #45347f;
-  --color-purple-800:  #30245c;
-  --color-purple-900:  #1c1438;
+  --color-purple-600:  #6651b9;
+  --color-purple-700:  #47347f;
+  --color-purple-800:  #31245b;
+  --color-purple-900:  #1d1336;
   --color-purple-1000: #0d0718;
 
   --color-green-300:  #7be9b4;
-  --color-green-400:  #55d99a;
-  --color-green-500:  #35b875;
-  --color-green-600:  #279b63;
+  --color-green-400:  #4cd39b;
+  --color-green-500:  #2da66a;
+  --color-green-600:  #238b59;
 
   --color-amber-300:  #ffe082;
   --color-amber-400:  #f2c94c;
 
   --color-red-300:  #ff9a9a;
   --color-red-400:  #ff8585;
-  --color-red-500:  #e0646b;
-  --color-red-600:  #cf5259;
+  --color-red-500:  #d85a62;
+  --color-red-600:  #c44952;
 
   --color-canvas:   var(--color-aqua-1000);
   --color-base:     var(--color-aqua-900);


### PR DESCRIPTION
## Overview

Extracts repeated inline UI patterns into a shared component library (`src/components/ui/` and `src/components/layout/`), reducing duplication across the codebase and making future styling changes apply from a single source.

## What changed

### New primitives — `src/components/ui/`

- **`Button.tsx`** — single `Button` component with `cva` variants: `accent`, `success`, `danger`, `ghost`, `icon`. Replaces 6+ inline button class strings spread across `AppsScreen`, `AppFormModal`, `ConfirmDialog`, and `SettingsScreen`.
- **`Toggle.tsx`** — unified toggle switch merging two divergent implementations (AppsScreen had `disabled` support and `w-9`; SettingsScreen had `w-10` and no `disabled`). Standardised to `w-9` with `disabled` prop.
- **`Input.tsx`** — exports `TextInput` and `NumberInput`, extracted from `AppFormModal`. Standardises input styling to `bg-elevated` (SettingsScreen inline input was using `bg-surface`).
- **`Checkbox.tsx`** — `CheckRow` extracted from `AppFormModal`. SVG check replaced with lucide `Check` icon for consistency.
- **`Badge.tsx`** — exports `StatusBadge` (variants: `running`, `crashed`, `idle`, `disabled`) extracted from `AppsScreen`, and `Tag` (plain pill) extracted from `HistoryScreen`.
- **`Modal.tsx`** — shared modal overlay (`fixed inset-0 z-50 … bg-black/60`) extracted from `AppFormModal` and `ConfirmDialog`, which had identical markup.
- **`Dropdown.tsx`** — headless dropdown that owns open state and click-outside logic, extracted from the identical boilerplate in `ThemeSelector` and `LanguageSelector`.
- **`EmptyState.tsx`** — `icon + message + optional action` pattern used in `AppsScreen`, `HistoryScreen`, and `LogScreen`.
- **`SectionDivider.tsx`** — labelled horizontal rule extracted from `AppFormModal`, now also used for section headings in `SettingsScreen`.

### New layout helpers — `src/components/layout/`

- **`ScreenHeader.tsx`** — `title + optional action` bar (`px-4 py-3 border-b`) extracted from `LogScreen` and `HistoryScreen`.
- **`FormField.tsx`** — `label + children + hint` wrapper extracted from `AppFormModal`. Used 6× in the same file and available for future forms.

### Extracted domain components

- **`AppAvatar.tsx`** — letter avatar moved out of `AppsScreen` (standalone, reusable).
- **`AppCard.tsx`** — 97-line app card component moved out of `AppsScreen` into its own file.

### Slimmed screen files

| File | Before | After |
|---|---|---|
| `AppsScreen.tsx` | 382 lines | ~100 lines |
| `AppFormModal.tsx` | 330 lines | ~130 lines |
| `SettingsScreen.tsx` | 165 lines | ~80 lines |
| `ThemeSelector.tsx` | 76 lines | ~35 lines |
| `LanguageSelector.tsx` | 68 lines | ~30 lines |

## Why

Several UI patterns (buttons, toggles, inputs, modals, dropdowns) were duplicated inline across multiple files. Any visual change required hunting down every instance — the Toggle alone had two diverging implementations. Extracting these into a shared library means:

- one place to fix a contrast issue, an interaction bug, or a size inconsistency
- screen files describe *layout and behavior*, not styling implementation
- `cva` (already a declared dependency, previously unused) now drives all button variants

## Screenshots / media

N/A — no user-visible behavior change. Pure structural refactor.

## Test plan

- [ ] Automated tests: `npm run test` — all existing tests pass (no logic changed)
- [ ] Build/typecheck: `npm run build` — zero TypeScript errors
- [ ] Manual verification: open each screen (Apps, Log, History, Settings), verify toggles, modals, dropdowns, buttons all render and behave identically to pre-refactor

## Implementation checklist

### Commits

- [ ] `refactor(ui): add Button primitive with cva variants`
- [ ] `refactor(ui): extract Toggle to shared component, fix SettingsScreen divergence`
- [ ] `refactor(ui): extract Input and Checkbox primitives from AppFormModal`
- [ ] `refactor(ui): extract Badge (StatusBadge + Tag)`
- [ ] `refactor(ui): extract Modal overlay`
- [ ] `refactor(ui): extract Dropdown base, slim ThemeSelector and LanguageSelector`
- [ ] `refactor(ui): add EmptyState, SectionDivider`
- [ ] `refactor(layout): add ScreenHeader and FormField`
- [ ] `refactor(apps): extract AppAvatar and AppCard to own files`
- [ ] `refactor(screens): consume new primitives in AppsScreen, AppFormModal, SettingsScreen`

### New files

- [ ] `src/components/ui/Button.tsx`
- [ ] `src/components/ui/Toggle.tsx`
- [ ] `src/components/ui/Input.tsx`
- [ ] `src/components/ui/Checkbox.tsx`
- [ ] `src/components/ui/Badge.tsx`
- [ ] `src/components/ui/Modal.tsx`
- [ ] `src/components/ui/Dropdown.tsx`
- [ ] `src/components/ui/EmptyState.tsx`
- [ ] `src/components/ui/SectionDivider.tsx`
- [ ] `src/components/layout/ScreenHeader.tsx`
- [ ] `src/components/layout/FormField.tsx`
- [ ] `src/components/AppAvatar.tsx`
- [ ] `src/components/AppCard.tsx`

### Files to slim down

- [ ] `src/components/screens/AppsScreen.tsx` (382 → ~100 lines)
- [ ] `src/components/AppFormModal.tsx` (330 → ~130 lines)
- [ ] `src/components/screens/SettingsScreen.tsx` (165 → ~80 lines)
- [ ] `src/components/ThemeSelector.tsx` (76 → ~35 lines)
- [ ] `src/components/LanguageSelector.tsx` (68 → ~30 lines)
- [ ] `src/components/ConfirmDialog.tsx` — consume `Modal` + `Button`
- [ ] `src/components/screens/LogScreen.tsx` — consume `ScreenHeader` + `EmptyState`
- [ ] `src/components/screens/HistoryScreen.tsx` — consume `ScreenHeader` + `EmptyState` + `Tag`

## Risk and rollout notes

No user-visible behavior changes. All components preserve existing props and rendered output exactly. The one intentional normalisation: `SettingsScreen` number input switches from `bg-surface` to `bg-elevated` for token consistency — visually imperceptible in both themes.

## Review focus

- `ui/Toggle.tsx` — the merged implementation (check that `disabled` state and thumb travel are correct for the `w-9` container)
- `ui/Dropdown.tsx` — click-outside and keyboard dismiss behaviour (verify `ThemeSelector` and `LanguageSelector` still close correctly)
- `ui/Button.tsx` — confirm `cva` variant map covers every call site without regressions
