### PR TITLE
refactor(ui/screens): extract useApps, useSettings, useCurrentTheme hooks

### DIFF
--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,7 +1,7 @@
 import { Check, ChevronDown, Palette } from 'lucide-react'
-import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { THEMES, getTheme, setTheme, type Theme } from '@/theme'
+import { THEMES, setTheme, type Theme } from '@/theme'
+import { useCurrentTheme } from '@/hooks/useCurrentTheme'
 import { cn } from '@/lib/cn'
 import { Dropdown } from '@/components/ui/Dropdown'
 
@@ -16,15 +16,7 @@ const SHORT: Record<Theme, string> = {
 
 export function ThemeSelector({ variant = 'default' }: ThemeSelectorProps) {
     const { t } = useTranslation()
-    const [current, setCurrent] = useState<Theme>(() => getTheme())
-
-    useEffect(() => {
-        function handleThemeChange(e: Event) {
-            setCurrent((e as CustomEvent<Theme>).detail)
-        }
-        window.addEventListener('pitlane:theme-change', handleThemeChange)
-        return () => window.removeEventListener('pitlane:theme-change', handleThemeChange)
-    }, [])
+    const current = useCurrentTheme()
 
     return (
         <Dropdown

--- a/src/components/screens/AppsScreen.tsx
+++ b/src/components/screens/AppsScreen.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { LayoutList, Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { api, type ManagedApp, type NewApp, type Profile } from '@/lib/api'
+import { api, type ManagedApp, type NewApp } from '@/lib/api'
+import { useApps } from '@/hooks/useApps'
 import { useAppStatuses } from '@/hooks/useAppStatuses'
 import { Button } from '@/components/ui/Button'
 import { Toggle } from '@/components/ui/Toggle'
@@ -14,55 +15,29 @@ type ModalState = { type: 'add' } | { type: 'edit'; app: ManagedApp } | null
 
 export function AppsScreen() {
     const { t } = useTranslation()
-    const [apps, setApps] = useState<ManagedApp[]>([])
-    const [activeProfile, setActiveProfile] = useState<Profile | null>(null)
+    const {
+        apps,
+        activeProfile,
+        preventAutoStop,
+        refresh,
+        toggleEnabled,
+        toggleStopWithIracing,
+        togglePreventAutoStop,
+        deleteApp,
+    } = useApps()
     const [modal, setModal] = useState<ModalState>(null)
     const [confirmDelete, setConfirmDelete] = useState<ManagedApp | null>(null)
-    const [preventAutoStop, setPreventAutoStop] = useState(false)
     const statuses = useAppStatuses()
-
-    async function loadApps() {
-        const [loadedApps, profiles, activeId, autoStopVal] = await Promise.all([
-            api.getApps(),
-            api.getProfiles(),
-            api.getActiveProfileId(),
-            api.getAutoStop(),
-        ])
-        setApps(loadedApps)
-        setActiveProfile(profiles.find((p) => p.id === activeId) ?? null)
-        setPreventAutoStop(!autoStopVal)
-    }
-
-    useEffect(() => {
-        loadApps()
-    }, [])
-
-    async function handlePreventAutoStopToggle() {
-        const next = !preventAutoStop
-        setPreventAutoStop(next)
-        await api.setAutoStop(!next)
-    }
 
     async function handleFormSubmit(data: NewApp) {
         if (modal?.type === 'add') await api.addApp(data)
         else if (modal?.type === 'edit') await api.updateApp(modal.app.id, data)
-        await loadApps()
+        await refresh()
     }
 
     async function handleDelete(app: ManagedApp) {
-        await api.deleteApp(app.id)
         setConfirmDelete(null)
-        loadApps()
-    }
-
-    async function handleToggleEnabled(app: ManagedApp, enabled: boolean) {
-        await api.updateApp(app.id, { enabled })
-        setApps((prev) => prev.map((a) => (a.id === app.id ? { ...a, enabled } : a)))
-    }
-
-    async function handleToggleStopWithIracing(app: ManagedApp, stop_with_iracing: boolean) {
-        await api.updateApp(app.id, { stop_with_iracing })
-        setApps((prev) => prev.map((a) => (a.id === app.id ? { ...a, stop_with_iracing } : a)))
+        await deleteApp(app)
     }
 
     return (
@@ -87,7 +62,7 @@ export function AppsScreen() {
                         </span>
                         <Toggle
                             checked={preventAutoStop}
-                            onChange={handlePreventAutoStopToggle}
+                            onChange={togglePreventAutoStop}
                             label={t('apps.auto_stop_label')}
                         />
                     </div>
@@ -120,9 +95,9 @@ export function AppsScreen() {
                             onStop={() => api.forceKillApp(app.id)}
                             onEdit={() => setModal({ type: 'edit', app })}
                             onDelete={() => setConfirmDelete(app)}
-                            onToggleEnabled={(enabled) => handleToggleEnabled(app, enabled)}
+                            onToggleEnabled={(enabled) => toggleEnabled(app, enabled)}
                             onToggleStopWithIracing={(stop) =>
-                                handleToggleStopWithIracing(app, stop)
+                                toggleStopWithIracing(app, stop)
                             }
                         />
                     ))}

--- a/src/components/screens/SettingsScreen.tsx
+++ b/src/components/screens/SettingsScreen.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, type Settings, type TriggerMode } from '@/lib/api'
+import { type TriggerMode } from '@/lib/api'
+import { useSettings } from '@/hooks/useSettings'
 import { Button } from '@/components/ui/Button'
 import { Toggle } from '@/components/ui/Toggle'
 import { NumberInput } from '@/components/ui/Input'
@@ -9,34 +9,9 @@ import { FormField } from '@/components/layout/FormField'
 import { LanguageSelector } from '@/components/LanguageSelector'
 import { ThemeSelector } from '@/components/ThemeSelector'
 
-const DEFAULT_SETTINGS: Settings = {
-    poll_interval_secs: 1,
-    default_trigger: 'ui',
-    notifications_enabled: true,
-    autostart: false,
-}
-
 export function SettingsScreen() {
     const { t } = useTranslation()
-    const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS)
-    const [saving, setSaving] = useState(false)
-
-    useEffect(() => {
-        api.getSettings().then(setSettings)
-    }, [])
-
-    function patch<K extends keyof Settings>(key: K, value: Settings[K]) {
-        setSettings((prev) => ({ ...prev, [key]: value }))
-    }
-
-    async function handleSave() {
-        setSaving(true)
-        try {
-            await api.saveSettings(settings)
-        } finally {
-            setSaving(false)
-        }
-    }
+    const { settings, patch, saving, handleSave } = useSettings()
 
     return (
         <div className="flex flex-col gap-6 p-4 h-full overflow-y-auto">

--- a/src/hooks/useApps.ts
+++ b/src/hooks/useApps.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect } from 'react'
+import { api, type ManagedApp, type Profile } from '@/lib/api'
+
+interface UseAppsResult {
+    apps: ManagedApp[]
+    activeProfile: Profile | null
+    preventAutoStop: boolean
+    refresh: () => Promise<void>
+    toggleEnabled: (app: ManagedApp, enabled: boolean) => Promise<void>
+    toggleStopWithIracing: (app: ManagedApp, stop_with_iracing: boolean) => Promise<void>
+    togglePreventAutoStop: () => Promise<void>
+    deleteApp: (app: ManagedApp) => Promise<void>
+}
+
+export function useApps(): UseAppsResult {
+    const [apps, setApps] = useState<ManagedApp[]>([])
+    const [activeProfile, setActiveProfile] = useState<Profile | null>(null)
+    const [preventAutoStop, setPreventAutoStop] = useState(false)
+
+    async function refresh() {
+        const [loadedApps, profiles, activeId, autoStopVal] = await Promise.all([
+            api.getApps(),
+            api.getProfiles(),
+            api.getActiveProfileId(),
+            api.getAutoStop(),
+        ])
+        setApps(loadedApps)
+        setActiveProfile(profiles.find((p) => p.id === activeId) ?? null)
+        setPreventAutoStop(!autoStopVal)
+    }
+
+    useEffect(() => {
+        refresh()
+    }, [])
+
+    async function toggleEnabled(app: ManagedApp, enabled: boolean) {
+        await api.updateApp(app.id, { enabled })
+        setApps((prev) => prev.map((a) => (a.id === app.id ? { ...a, enabled } : a)))
+    }
+
+    async function toggleStopWithIracing(app: ManagedApp, stop_with_iracing: boolean) {
+        await api.updateApp(app.id, { stop_with_iracing })
+        setApps((prev) => prev.map((a) => (a.id === app.id ? { ...a, stop_with_iracing } : a)))
+    }
+
+    async function togglePreventAutoStop() {
+        const next = !preventAutoStop
+        setPreventAutoStop(next)
+        await api.setAutoStop(!next)
+    }
+
+    async function deleteApp(app: ManagedApp) {
+        await api.deleteApp(app.id)
+        await refresh()
+    }
+
+    return {
+        apps,
+        activeProfile,
+        preventAutoStop,
+        refresh,
+        toggleEnabled,
+        toggleStopWithIracing,
+        togglePreventAutoStop,
+        deleteApp,
+    }
+}

--- a/src/hooks/useCurrentTheme.ts
+++ b/src/hooks/useCurrentTheme.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from 'react'
+import { getTheme, type Theme } from '@/theme'
+
+export function useCurrentTheme(): Theme {
+    const [current, setCurrent] = useState<Theme>(() => getTheme())
+
+    useEffect(() => {
+        function handleThemeChange(e: Event) {
+            setCurrent((e as CustomEvent<Theme>).detail)
+        }
+        window.addEventListener('pitlane:theme-change', handleThemeChange)
+        return () => window.removeEventListener('pitlane:theme-change', handleThemeChange)
+    }, [])
+
+    return current
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react'
+import { api, type Settings } from '@/lib/api'
+
+const DEFAULT_SETTINGS: Settings = {
+    poll_interval_secs: 1,
+    default_trigger: 'ui',
+    notifications_enabled: true,
+    autostart: false,
+}
+
+interface UseSettingsResult {
+    settings: Settings
+    patch: <K extends keyof Settings>(key: K, value: Settings[K]) => void
+    saving: boolean
+    handleSave: () => Promise<void>
+}
+
+export function useSettings(): UseSettingsResult {
+    const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS)
+    const [saving, setSaving] = useState(false)
+
+    useEffect(() => {
+        api.getSettings().then(setSettings)
+    }, [])
+
+    function patch<K extends keyof Settings>(key: K, value: Settings[K]) {
+        setSettings((prev) => ({ ...prev, [key]: value }))
+    }
+
+    async function handleSave() {
+        setSaving(true)
+        try {
+            await api.saveSettings(settings)
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    return { settings, patch, saving, handleSave }
+}


### PR DESCRIPTION
## Overview

Extract inline data logic from screen components into dedicated React hooks, keeping components focused on rendering.

## What changed

- **`src/hooks/useApps.ts`** — new hook consolidating `AppsScreen` data logic: load (Promise.all of getApps/getProfiles/getActiveProfileId/getAutoStop), optimistic toggles for `enabled` and `stop_with_iracing`, `togglePreventAutoStop`, `deleteApp`, and `refresh`
- **`src/hooks/useSettings.ts`** — new hook with load-on-mount, generic `patch<K>`, `saving` state, and `handleSave`
- **`src/hooks/useCurrentTheme.ts`** — new hook that subscribes to `pitlane:theme-change` and returns the current `Theme`
- **`AppsScreen.tsx`**, **`SettingsScreen.tsx`**, **`ThemeSelector.tsx`** — updated to consume the new hooks; modal and confirm-dialog state remains in components (UI-only)

## Why

Screen components were mixing data-fetching, optimistic updates, and render logic. Hooks make the data layer testable in isolation and leave the components as nearly-pure JSX. Follows the pattern already established by `useAppStatuses` and `useLog`.

## Screenshots / media

No visual changes.

## Test plan

- [x] All 84 existing tests pass (`npm run test -- --run`)
- [x] No pre-refactor tests needed — existing `AppsScreen.test.tsx` and `SettingsScreen.test.tsx` cover the extracted behaviour at the component level

## Risk and rollout notes

Pure refactor — no behaviour changes, no API surface changes. Low risk.

## Review focus

- `useApps.ts`: confirm `deleteApp` calls `refresh()` internally (removes the `setConfirmDelete(null)` coupling that was in the component)
- `useSettings.ts`: `DEFAULT_SETTINGS` moved from `SettingsScreen` into the hook — verify this is the right home