### PR TITLE
docs(ui): complete visual inventory

### DIFF
--- a/docs/TODO/ui-redesign-delivery-tracker.md
+++ b/docs/TODO/ui-redesign-delivery-tracker.md
@@ -47,7 +47,7 @@ Fora de escopo:
 
 | Status | ID | Sub-issue | Entrega esperada | Arquivos/áreas principais | Verificação mínima | Entregue em |
 | --- | --- | --- | --- | --- | --- | --- |
-| [ ] | UI-00 | Preparar base visual e inventário | Confirmar tokens Aurora, mapear diferenças da referência visual e registrar decisões que não exigem código | `src/index.css`, `docs/TODO/ui-redesign-v0-plan.md` | `npm run format:check` se houver mudança em código | |
+| [x] | UI-00 | Preparar base visual e inventário | Confirmar tokens Aurora, mapear diferenças da referência visual e registrar decisões que não exigem código | `src/index.css`, `docs/TODO/ui-redesign-v0-plan.md` | `npm run format:check` se houver mudança em código | 2026-05-01 |
 | [ ] | UI-01 | Componentes base do redesign | Criar/evoluir `IconButton`, `StatusPill`, `Panel`, `MetricTile`, `Toolbar`, `ActivityRow` sem trocar telas ainda | `src/components/ui`, `src/components/layout` | Testes unitários dos componentes novos; `npm run test` | |
 | [ ] | UI-02 | Novo modelo de navegação | Atualizar o tipo de tabs, i18n de navegação e sidebar para `command`, `apps`, `profiles`, `automation`, `logs`, `settings`, sem renderizar telas futuras como funcionais | `Sidebar`, `App.tsx`, i18n | Teste de tabs; confirmar que `Integrations` não aparece | |
 | [ ] | UI-03 | App shell V0 | Introduzir `AppShell`, `TopBar` e `BottomStatusBar`, preservando telas existentes dentro do novo layout | `App.tsx`, componentes de shell | Build e screenshot manual/Playwright do shell | |
@@ -98,3 +98,4 @@ Motivo da ordem: primeiro estabilizar tokens, componentes e shell; depois entreg
 | 2026-05-01 | `Integrations` fora de escopo | A tab foi marcada como `not intended` e removida do plano. |
 | 2026-05-01 | `Profiles` como `Future-0` | Alta prioridade futura, mas sem CRUD/API suficiente para V0. |
 | 2026-05-01 | `Automation` como `Future-1` | Deve existir depois de Profiles, usando regras globais sem duplicar Settings. |
+| 2026-05-01 | Aurora tokens já batem com a referência | `src/index.css` já contém as rampas e tokens semânticos da paleta `pitlane-aurora-palette-reference.png`; UI-00 não exige alteração de CSS. |

--- a/docs/TODO/ui-redesign-delivery-tracker.md
+++ b/docs/TODO/ui-redesign-delivery-tracker.md
@@ -48,6 +48,7 @@ Fora de escopo:
 | Status | ID | Sub-issue | Entrega esperada | Arquivos/áreas principais | Verificação mínima | Entregue em |
 | --- | --- | --- | --- | --- | --- | --- |
 | [x] | UI-00 | Preparar base visual e inventário | Confirmar tokens Aurora, mapear diferenças da referência visual e registrar decisões que não exigem código | `src/index.css`, `docs/TODO/ui-redesign-v0-plan.md` | `npm run format:check` se houver mudança em código | 2026-05-01 |
+| [ ] | UI-00B | Definir estratégia de styling do redesign | Reduzir verbosidade do Tailwind com regras de encapsulamento, `cva` e classes semânticas pontuais antes dos componentes base | `src/components/ui`, `src/components/layout`, `src/index.css`, docs do redesign | Revisão do padrão documentado; `npm run format:check` se houver mudança em código | |
 | [ ] | UI-01 | Componentes base do redesign | Criar/evoluir `IconButton`, `StatusPill`, `Panel`, `MetricTile`, `Toolbar`, `ActivityRow` sem trocar telas ainda | `src/components/ui`, `src/components/layout` | Testes unitários dos componentes novos; `npm run test` | |
 | [ ] | UI-02 | Novo modelo de navegação | Atualizar o tipo de tabs, i18n de navegação e sidebar para `command`, `apps`, `profiles`, `automation`, `logs`, `settings`, sem renderizar telas futuras como funcionais | `Sidebar`, `App.tsx`, i18n | Teste de tabs; confirmar que `Integrations` não aparece | |
 | [ ] | UI-03 | App shell V0 | Introduzir `AppShell`, `TopBar` e `BottomStatusBar`, preservando telas existentes dentro do novo layout | `App.tsx`, componentes de shell | Build e screenshot manual/Playwright do shell | |
@@ -64,20 +65,21 @@ Fora de escopo:
 ## Ordem Recomendada
 
 1. UI-00
-2. UI-01
-3. UI-02
-4. UI-03
-5. UI-04
-6. UI-05
-7. UI-06
-8. UI-08
-9. UI-09
-10. UI-07
-11. UI-10
-12. UI-11
-13. UI-12
+2. UI-00B
+3. UI-01
+4. UI-02
+5. UI-03
+6. UI-04
+7. UI-05
+8. UI-06
+9. UI-08
+10. UI-09
+11. UI-07
+12. UI-10
+13. UI-11
+14. UI-12
 
-Motivo da ordem: primeiro estabilizar tokens, componentes e shell; depois entregar o Command Center; em seguida adaptar telas existentes; por fim refinar modal, placeholders e acessibilidade.
+Motivo da ordem: primeiro estabilizar tokens e padrão de styling, depois criar componentes e shell; em seguida entregar o Command Center; depois adaptar telas existentes; por fim refinar modal, placeholders e acessibilidade.
 
 ## Critérios De Aceite Da Issue Principal
 
@@ -99,3 +101,4 @@ Motivo da ordem: primeiro estabilizar tokens, componentes e shell; depois entreg
 | 2026-05-01 | `Profiles` como `Future-0` | Alta prioridade futura, mas sem CRUD/API suficiente para V0. |
 | 2026-05-01 | `Automation` como `Future-1` | Deve existir depois de Profiles, usando regras globais sem duplicar Settings. |
 | 2026-05-01 | Aurora tokens já batem com a referência | `src/index.css` já contém as rampas e tokens semânticos da paleta `pitlane-aurora-palette-reference.png`; UI-00 não exige alteração de CSS. |
+| 2026-05-01 | Styling do redesign deve reduzir Tailwind verboso sem trocar stack | Manter Tailwind v4, mas concentrar classes longas em componentes base, usar `cva` para variantes e permitir classes semânticas pontuais apenas para padrões estruturais repetidos. |

--- a/docs/TODO/ui-redesign-v0-plan.md
+++ b/docs/TODO/ui-redesign-v0-plan.md
@@ -94,6 +94,8 @@ Avoid duplicating API calls inside both shell and screen when the same data can 
 
 Use `Pitlane Aurora` as the primary theme. Before implementation, compare `docs/TODO/pitlane-aurora-palette-reference.png` with `src/index.css` and only adjust tokens when there is an actual mismatch.
 
+UI-00 result: the Aurora ramp and semantic tokens in `src/index.css` already match the palette reference. No token patch is required before component work starts.
+
 Required visual rules:
 
 - Main surfaces remain dark purple with aqua used for primary action and focus.

--- a/docs/TODO/ui-redesign-v0-plan.md
+++ b/docs/TODO/ui-redesign-v0-plan.md
@@ -112,6 +112,20 @@ The screenshot uses a subtle cockpit-like background treatment in the hero/statu
 
 Consolidate these components before screen work:
 
+### Styling Strategy
+
+The redesign should keep Tailwind CSS v4, but avoid spreading long utility strings through screen files.
+
+Rules for V0:
+
+- Screen components should prefer semantic components (`Panel`, `Toolbar`, `AppCommandRow`, `ActivityRow`, `MetricTile`) over repeated `className` blocks.
+- Component variants should use `cva` when a component has meaningful variants, sizes, or state-driven styles.
+- `cn(...)` should stay for short conditional composition, not as a place to hide large one-off layouts.
+- Long Tailwind class strings are acceptable inside low-level reusable components, but should not dominate screen-level JSX.
+- `src/index.css` may define small semantic classes only for repeated structural patterns that are awkward as components; do not create a broad parallel CSS framework.
+- Do not migrate away from Tailwind, introduce CSS-in-JS, or add another styling dependency for V0.
+- When unsure, create a focused component before adding a page-local styling abstraction.
+
 ### Existing Components To Reuse
 
 - `Button`


### PR DESCRIPTION
## Summary

- Confirms the Aurora palette reference already matches the tokens in `src/index.css`.
- Marks `UI-00` as delivered in the redesign tracker.
- Adds `UI-00B` to capture the Tailwind styling strategy before base component work starts.

## Verification

- Documentation-only change; no tests run.

Closes #23
Refs #36
