### PR TITLE
docs(ui): complete styling strategy

### DIFF
--- a/docs/TODO/ui-redesign-delivery-tracker.md
+++ b/docs/TODO/ui-redesign-delivery-tracker.md
@@ -7,6 +7,7 @@ Este arquivo guia a implementação incremental do redesign da interface. Ele de
 Referências:
 
 - Plano técnico: `docs/TODO/ui-redesign-v0-plan.md`
+- Estratégia de styling: `docs/TODO/ui-redesign-styling-strategy.md`
 - Escopo das tabs: `docs/TODO/ui-redesign-tab-scope.md`
 - Referência visual: `docs/TODO/ui-redesign-command-center-reference.png`
 - Paleta: `docs/TODO/pitlane-aurora-palette-reference.png`
@@ -48,7 +49,7 @@ Fora de escopo:
 | Status | ID | Sub-issue | Entrega esperada | Arquivos/áreas principais | Verificação mínima | Entregue em |
 | --- | --- | --- | --- | --- | --- | --- |
 | [x] | UI-00 | Preparar base visual e inventário | Confirmar tokens Aurora, mapear diferenças da referência visual e registrar decisões que não exigem código | `src/index.css`, `docs/TODO/ui-redesign-v0-plan.md` | `npm run format:check` se houver mudança em código | 2026-05-01 |
-| [ ] | UI-00B | Definir estratégia de styling do redesign | Reduzir verbosidade do Tailwind com regras de encapsulamento, `cva` e classes semânticas pontuais antes dos componentes base | `src/components/ui`, `src/components/layout`, `src/index.css`, docs do redesign | Revisão do padrão documentado; `npm run format:check` se houver mudança em código | |
+| [x] | UI-00B | Definir estratégia de styling do redesign | Reduzir verbosidade do Tailwind com regras de encapsulamento, `cva` e classes semânticas pontuais antes dos componentes base | `src/components/ui`, `src/components/layout`, `src/index.css`, docs do redesign | Revisão do padrão documentado; `npm run format:check` se houver mudança em código | 2026-05-01 |
 | [ ] | UI-01 | Componentes base do redesign | Criar/evoluir `IconButton`, `StatusPill`, `Panel`, `MetricTile`, `Toolbar`, `ActivityRow` sem trocar telas ainda | `src/components/ui`, `src/components/layout` | Testes unitários dos componentes novos; `npm run test` | |
 | [ ] | UI-02 | Novo modelo de navegação | Atualizar o tipo de tabs, i18n de navegação e sidebar para `command`, `apps`, `profiles`, `automation`, `logs`, `settings`, sem renderizar telas futuras como funcionais | `Sidebar`, `App.tsx`, i18n | Teste de tabs; confirmar que `Integrations` não aparece | |
 | [ ] | UI-03 | App shell V0 | Introduzir `AppShell`, `TopBar` e `BottomStatusBar`, preservando telas existentes dentro do novo layout | `App.tsx`, componentes de shell | Build e screenshot manual/Playwright do shell | |

--- a/docs/TODO/ui-redesign-styling-strategy.md
+++ b/docs/TODO/ui-redesign-styling-strategy.md
@@ -1,0 +1,106 @@
+# UI Redesign Styling Strategy
+
+Date: 2026-05-01
+
+This document defines how the redesign should reduce Tailwind verbosity without changing the styling stack.
+
+## Decision
+
+Keep Tailwind CSS v4 for V0. Do not migrate to CSS Modules, CSS-in-JS, styled-components, or a different styling system during the redesign.
+
+The readability problem should be solved by moving repeated visual patterns into reusable components and variant helpers.
+
+## Rules
+
+- Screen files should describe product structure, not low-level styling.
+- Repeated UI patterns should become components before they become repeated `className` strings.
+- Components with variants, sizes, or state-driven styles should use `cva`.
+- `cn(...)` is for short conditional composition only.
+- Long Tailwind strings are acceptable inside low-level reusable components.
+- Long Tailwind strings should not dominate screen-level JSX.
+- Small semantic classes in `src/index.css` are allowed only for repeated structural patterns that are awkward as components.
+- Do not create a broad parallel CSS framework in `src/index.css`.
+
+## Preferred Pattern
+
+Screen-level JSX should read like this:
+
+```tsx
+<Panel>
+    <PanelHeader title={title} action={<Toolbar>{actions}</Toolbar>} />
+    <AppCommandRow app={app} status={status} />
+</Panel>
+```
+
+Avoid screen-level JSX that repeats full visual construction:
+
+```tsx
+<section className="rounded-lg border border-border bg-surface px-4 py-3 shadow-sm ...">
+    <div className="flex items-center justify-between gap-3 border-b border-border pb-3 ...">
+        ...
+    </div>
+</section>
+```
+
+If the second pattern appears more than once, create or extend a component.
+
+## Component Guidance
+
+Use `cva` for:
+
+- `Button`
+- `IconButton`
+- `StatusPill`
+- `Panel`
+- `MetricTile`
+- `ActivityRow`
+- `AppCommandRow`
+
+Use plain `className` for:
+
+- tiny wrappers with no variants
+- one-off flex/grid positioning inside a component
+- local spacing where extracting a component would obscure intent
+
+Use semantic CSS classes only when:
+
+- the same structural class set appears in several components
+- the class is tied to layout behavior rather than product meaning
+- the name is generic and durable, such as `.app-scroll-area`
+
+Do not use semantic CSS classes for:
+
+- one-off page styling
+- status colors that already have tokens
+- component variants better represented with `cva`
+- hiding complex product behavior behind an unclear class name
+
+## Naming
+
+Component names should describe UI responsibility:
+
+- `Panel`
+- `Toolbar`
+- `MetricTile`
+- `StatusPill`
+- `ActivityRow`
+- `AppCommandRow`
+
+Avoid names that encode styling implementation:
+
+- `PurpleCard`
+- `FlexBoxPanel`
+- `GradientHeader`
+- `BorderedThing`
+
+## Review Checklist
+
+Before merging a UI redesign PR:
+
+- [ ] Screen files remain readable at product level.
+- [ ] Repeated Tailwind blocks are componentized.
+- [ ] Components with variants use `cva`.
+- [ ] `cn(...)` is not hiding large layout strings.
+- [ ] New semantic CSS classes are minimal and justified.
+- [ ] No new styling dependency was added.
+- [ ] No migration away from Tailwind was introduced.

--- a/docs/TODO/ui-redesign-v0-plan.md
+++ b/docs/TODO/ui-redesign-v0-plan.md
@@ -116,6 +116,8 @@ Consolidate these components before screen work:
 
 The redesign should keep Tailwind CSS v4, but avoid spreading long utility strings through screen files.
 
+Detailed guide: `docs/TODO/ui-redesign-styling-strategy.md`.
+
 Rules for V0:
 
 - Screen components should prefer semantic components (`Panel`, `Toolbar`, `AppCommandRow`, `ActivityRow`, `MetricTile`) over repeated `className` blocks.


### PR DESCRIPTION
## Summary

- Adds a dedicated styling strategy guide for the UI redesign.
- Keeps Tailwind v4 as the styling stack while defining how to reduce utility-class verbosity.
- Marks `UI-00B` as delivered in the tracker and links it from the V0 plan.

## Verification

- Documentation-only change; no tests run.

Closes #36
