### PR TITLE
fix(app-stop-behavior): Windows Job Objects, localized logs, and watchdog fixes

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,9 @@ windows = { version = "0.58", features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_Threading",
+    "Win32_Security",
     "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_JobObjects",
     "Win32_System_Registry",
     "Win32_UI_Shell",
 ] }

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -338,9 +338,21 @@ impl Controller {
                         let pid = launcher::resolve_real_pid(stub_pid, &app);
                         #[cfg(debug_assertions)]
                         println!("[controller] '{}' pid={pid}", app.name);
-                        if let Ok(job) = process_killer::ProcessJob::new() {
-                            let _ = job.assign(pid);
-                            jobs.lock().unwrap().insert(app.id.clone(), job);
+                        match process_killer::ProcessJob::new() {
+                            Ok(job) => {
+                                match job.assign(pid) {
+                                    Ok(()) => {
+                                        println!("[controller] '{}' assigned to job object", app.name);
+                                        jobs.lock().unwrap().insert(app.id.clone(), job);
+                                    }
+                                    Err(e) => {
+                                        println!("[controller] '{}' job assign failed: {e}", app.name);
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                println!("[controller] '{}' job creation failed: {e}", app.name);
+                            }
                         }
                         watchdog.watch(app.clone(), pid);
                         logic.lock().unwrap().on_app_launched(&app.id, pid);
@@ -411,8 +423,10 @@ impl Controller {
 
                 Some(thread::spawn(move || {
                     if let Some(job) = jobs.lock().unwrap().remove(&app.id) {
+                        println!("[controller] killing '{}' via job object", app.name);
                         job.kill_all();
                     } else {
+                        println!("[controller] killing '{}' via legacy kill_app (no job found)", app.name);
                         let grace = if app.force_kill_on_stop { 0.0 } else { DEFAULT_GRACE_SECS };
                         kill_app(&app, grace);
                     }
@@ -465,9 +479,21 @@ impl Controller {
 
         let stub_pid = launcher::launch(&app).map_err(|e| e.to_string())?;
         let pid = launcher::resolve_real_pid(stub_pid, &app);
-        if let Ok(job) = process_killer::ProcessJob::new() {
-            let _ = job.assign(pid);
-            self.jobs.lock().unwrap().insert(app.id.clone(), job);
+        match process_killer::ProcessJob::new() {
+            Ok(job) => {
+                match job.assign(pid) {
+                    Ok(()) => {
+                        println!("[controller] force_launch '{}' assigned to job object", app.name);
+                        self.jobs.lock().unwrap().insert(app.id.clone(), job);
+                    }
+                    Err(e) => {
+                        println!("[controller] force_launch '{}' job assign failed: {e}", app.name);
+                    }
+                }
+            }
+            Err(e) => {
+                println!("[controller] force_launch '{}' job creation failed: {e}", app.name);
+            }
         }
         self.watchdog.watch(app.clone(), pid);
         self.logic.lock().unwrap().on_app_launched(app_id, pid);

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -188,6 +188,7 @@ pub struct Controller {
     iracing_online: Arc<AtomicBool>,
     auto_stop: Arc<AtomicBool>,
     sink: Arc<LogSink>,
+    jobs: Arc<Mutex<HashMap<String, process_killer::ProcessJob>>>,
     _monitor: std::sync::OnceLock<Monitor>,
 }
 
@@ -229,6 +230,7 @@ impl Controller {
             iracing_online: Arc::clone(&iracing_online),
             auto_stop: Arc::clone(&auto_stop),
             sink,
+            jobs: Arc::new(Mutex::new(HashMap::new())),
             _monitor: std::sync::OnceLock::new(),
         });
 
@@ -323,6 +325,7 @@ impl Controller {
             let logic = Arc::clone(&self.logic);
             let watchdog = Arc::clone(&self.watchdog);
             let sink = Arc::clone(&self.sink);
+            let jobs = Arc::clone(&self.jobs);
 
             thread::spawn(move || {
                 if app.startup_delay_secs > 0.0 {
@@ -335,6 +338,10 @@ impl Controller {
                         let pid = launcher::resolve_real_pid(stub_pid, &app);
                         #[cfg(debug_assertions)]
                         println!("[controller] '{}' pid={pid}", app.name);
+                        if let Ok(job) = process_killer::ProcessJob::new() {
+                            let _ = job.assign(pid);
+                            jobs.lock().unwrap().insert(app.id.clone(), job);
+                        }
                         watchdog.watch(app.clone(), pid);
                         logic.lock().unwrap().on_app_launched(&app.id, pid);
                         sink.push(
@@ -385,6 +392,7 @@ impl Controller {
             ids
         };
 
+        let jobs = Arc::clone(&self.jobs);
         let handles: Vec<_> = ids_to_kill
             .iter()
             .filter_map(|app_id| {
@@ -399,10 +407,15 @@ impl Controller {
                     .find(|a| a.id == *app_id)
                     .cloned()?;
                 let sink = Arc::clone(&self.sink);
+                let jobs = Arc::clone(&jobs);
 
                 Some(thread::spawn(move || {
-                    let grace = if app.force_kill_on_stop { 0.0 } else { DEFAULT_GRACE_SECS };
-                    kill_app(&app, grace);
+                    if let Some(job) = jobs.lock().unwrap().remove(&app.id) {
+                        job.kill_all();
+                    } else {
+                        let grace = if app.force_kill_on_stop { 0.0 } else { DEFAULT_GRACE_SECS };
+                        kill_app(&app, grace);
+                    }
                     sink.push(LogKind::Stop, Some(app.name.clone()), String::new());
                 }))
             })
@@ -452,6 +465,10 @@ impl Controller {
 
         let stub_pid = launcher::launch(&app).map_err(|e| e.to_string())?;
         let pid = launcher::resolve_real_pid(stub_pid, &app);
+        if let Ok(job) = process_killer::ProcessJob::new() {
+            let _ = job.assign(pid);
+            self.jobs.lock().unwrap().insert(app.id.clone(), job);
+        }
         self.watchdog.watch(app.clone(), pid);
         self.logic.lock().unwrap().on_app_launched(app_id, pid);
         Ok(())
@@ -467,7 +484,9 @@ impl Controller {
         }
         self.watchdog.unwatch(app_id);
 
-        if let Some(app) = self
+        if let Some(job) = self.jobs.lock().unwrap().remove(app_id) {
+            job.kill_all();
+        } else if let Some(app) = self
             .config
             .lock()
             .unwrap()
@@ -477,6 +496,16 @@ impl Controller {
             .cloned()
         {
             kill_app(&app, DEFAULT_GRACE_SECS);
+        }
+
+        if let Some(app) = self
+            .config
+            .lock()
+            .unwrap()
+            .apps
+            .iter()
+            .find(|a| a.id == app_id)
+        {
             self.sink
                 .push(LogKind::Stop, Some(app.name.clone()), String::new());
         }

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -20,6 +20,7 @@ const MAX_LOG_ENTRIES: usize = 200;
 pub enum LogKind {
     Launch,
     Stop,
+    Crashed,
     IracingStart,
     IracingStop,
 }
@@ -124,8 +125,13 @@ impl ControllerLogic {
         );
     }
 
-    pub fn on_app_gave_up(&mut self, app_id: &str) {
+    pub fn on_app_gave_up(&mut self, app_id: &str) -> u32 {
+        let last_restart_count = match self.states.get(app_id) {
+            Some(AppState::Running { restart_count, .. }) => *restart_count,
+            _ => 0,
+        };
         self.states.insert(app_id.to_string(), AppState::Crashed);
+        last_restart_count
     }
 
     pub fn app_state(&self, app_id: &str) -> AppState {
@@ -236,6 +242,7 @@ impl Controller {
 
         // Thread: consume watchdog events and update logic state
         let ctrl_wd = Arc::clone(&ctrl);
+        let sink_wd = Arc::clone(&ctrl.sink);
         thread::spawn(move || {
             for event in watchdog_rx {
                 match event {
@@ -251,7 +258,23 @@ impl Controller {
                             .on_app_restarted(&app_id, new_pid, attempt);
                     }
                     WatchdogEvent::GaveUp { app_id } | WatchdogEvent::RestartFailed { app_id } => {
-                        ctrl_wd.logic.lock().unwrap().on_app_gave_up(&app_id);
+                        let restart_count = ctrl_wd.logic.lock().unwrap().on_app_gave_up(&app_id);
+                        // Log the crash
+                        if let Some(app) = ctrl_wd
+                            .config
+                            .lock()
+                            .unwrap()
+                            .apps
+                            .iter()
+                            .find(|a| a.id == app_id)
+                            .cloned()
+                        {
+                            sink_wd.push(
+                                LogKind::Crashed,
+                                Some(app.name.clone()),
+                                format!("crashed (restart {restart_count}/{})", app.max_restart_attempts),
+                            );
+                        }
                     }
                 }
             }
@@ -259,13 +282,14 @@ impl Controller {
 
         // Monitor callback — spawns threads so the monitor is never blocked
         let ctrl_mon = Arc::clone(&ctrl);
+        let process_name = crate::monitor::process_name_for(&trigger).to_string();
         let monitor = Monitor::start(trigger, poll_interval, move |event| match event {
             MonitorEvent::Started => {
                 iracing_online.store(true, Ordering::Relaxed);
                 on_status(true);
                 let c = Arc::clone(&ctrl_mon);
                 c.sink
-                    .push(LogKind::IracingStart, None, "iRacing detected".into());
+                    .push(LogKind::IracingStart, None, format!("{process_name} started"));
                 thread::spawn(move || c.launch_active_apps());
             }
             MonitorEvent::Stopped => {
@@ -273,7 +297,7 @@ impl Controller {
                 on_status(false);
                 let c = Arc::clone(&ctrl_mon);
                 c.sink
-                    .push(LogKind::IracingStop, None, "iRacing closed".into());
+                    .push(LogKind::IracingStop, None, format!("{process_name} stopped"));
                 if auto_stop.load(Ordering::Relaxed) {
                     thread::spawn(move || c.kill_all_running());
                 }
@@ -362,16 +386,16 @@ impl Controller {
                         sink.push(
                             LogKind::Launch,
                             Some(app.name.clone()),
-                            format!("pid {pid}"),
+                            format!("started (pid {pid})"),
                         );
                     }
                     Err(e) => {
                         #[cfg(debug_assertions)]
                         eprintln!("[controller] FAILED to launch '{}': {e}", app.name);
                         sink.push(
-                            LogKind::Launch,
+                            LogKind::Crashed,
                             Some(app.name.clone()),
-                            format!("FAILED: {e}"),
+                            format!("failed to start: {e}"),
                         );
                     }
                 }
@@ -434,7 +458,7 @@ impl Controller {
                     println!("[controller] killing '{}' via exe_path fallback", app.name);
                     let grace = if app.force_kill_on_stop { 0.0 } else { DEFAULT_GRACE_SECS };
                     process_killer::kill_by_exe_path(&app.exe_path, grace);
-                    sink.push(LogKind::Stop, Some(app.name.clone()), String::new());
+                    sink.push(LogKind::Stop, Some(app.name.clone()), "stopped".into());
                 }))
             })
             .collect();

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -68,7 +68,7 @@ impl LogSink {
     }
 }
 
-const DEFAULT_GRACE_SECS: f64 = 2.0;
+const DEFAULT_GRACE_SECS: f64 = 0.5;
 
 // ── App state ─────────────────────────────────────────────────────────────────
 

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -68,7 +68,7 @@ impl LogSink {
     }
 }
 
-const DEFAULT_GRACE_SECS: f64 = 5.0;
+const DEFAULT_GRACE_SECS: f64 = 2.0;
 
 // ── App state ─────────────────────────────────────────────────────────────────
 

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -335,25 +335,28 @@ impl Controller {
                 println!("[controller] launching '{}'", app.name);
                 match launcher::launch(&app) {
                     Ok(stub_pid) => {
+                        // Create job immediately so any child processes spawned
+                        // by the app will inherit the job.
+                        let job = process_killer::ProcessJob::new().ok();
+                        if let Some(ref j) = job {
+                            if let Err(e) = j.assign(stub_pid) {
+                                println!("[controller] '{}' stub job assign failed: {e}", app.name);
+                            }
+                        }
+
                         let pid = launcher::resolve_real_pid(stub_pid, &app);
                         #[cfg(debug_assertions)]
                         println!("[controller] '{}' pid={pid}", app.name);
-                        match process_killer::ProcessJob::new() {
-                            Ok(job) => {
-                                match job.assign(pid) {
-                                    Ok(()) => {
-                                        println!("[controller] '{}' assigned to job object", app.name);
-                                        jobs.lock().unwrap().insert(app.id.clone(), job);
-                                    }
-                                    Err(e) => {
-                                        println!("[controller] '{}' job assign failed: {e}", app.name);
-                                    }
+
+                        if let Some(j) = job {
+                            if pid != stub_pid {
+                                if let Err(e) = j.assign(pid) {
+                                    println!("[controller] '{}' resolved job assign failed: {e}", app.name);
                                 }
                             }
-                            Err(e) => {
-                                println!("[controller] '{}' job creation failed: {e}", app.name);
-                            }
+                            jobs.lock().unwrap().insert(app.id.clone(), j);
                         }
+
                         watchdog.watch(app.clone(), pid);
                         logic.lock().unwrap().on_app_launched(&app.id, pid);
                         sink.push(
@@ -425,11 +428,12 @@ impl Controller {
                     if let Some(job) = jobs.lock().unwrap().remove(&app.id) {
                         println!("[controller] killing '{}' via job object", app.name);
                         job.kill_all();
-                    } else {
-                        println!("[controller] killing '{}' via legacy kill_app (no job found)", app.name);
-                        let grace = if app.force_kill_on_stop { 0.0 } else { DEFAULT_GRACE_SECS };
-                        kill_app(&app, grace);
                     }
+                    // Fallback: kill any processes that escaped the job (e.g. spawned
+                    // before we could assign, or with CREATE_BREAKAWAY_FROM_JOB).
+                    println!("[controller] killing '{}' via exe_path fallback", app.name);
+                    let grace = if app.force_kill_on_stop { 0.0 } else { DEFAULT_GRACE_SECS };
+                    process_killer::kill_by_exe_path(&app.exe_path, grace);
                     sink.push(LogKind::Stop, Some(app.name.clone()), String::new());
                 }))
             })
@@ -478,23 +482,23 @@ impl Controller {
         }
 
         let stub_pid = launcher::launch(&app).map_err(|e| e.to_string())?;
-        let pid = launcher::resolve_real_pid(stub_pid, &app);
-        match process_killer::ProcessJob::new() {
-            Ok(job) => {
-                match job.assign(pid) {
-                    Ok(()) => {
-                        println!("[controller] force_launch '{}' assigned to job object", app.name);
-                        self.jobs.lock().unwrap().insert(app.id.clone(), job);
-                    }
-                    Err(e) => {
-                        println!("[controller] force_launch '{}' job assign failed: {e}", app.name);
-                    }
-                }
-            }
-            Err(e) => {
-                println!("[controller] force_launch '{}' job creation failed: {e}", app.name);
+        let job = process_killer::ProcessJob::new().ok();
+        if let Some(ref j) = job {
+            if let Err(e) = j.assign(stub_pid) {
+                println!("[controller] force_launch '{}' stub job assign failed: {e}", app.name);
             }
         }
+
+        let pid = launcher::resolve_real_pid(stub_pid, &app);
+        if let Some(j) = job {
+            if pid != stub_pid {
+                if let Err(e) = j.assign(pid) {
+                    println!("[controller] force_launch '{}' resolved job assign failed: {e}", app.name);
+                }
+            }
+            self.jobs.lock().unwrap().insert(app.id.clone(), j);
+        }
+
         self.watchdog.watch(app.clone(), pid);
         self.logic.lock().unwrap().on_app_launched(app_id, pid);
         Ok(())
@@ -510,18 +514,21 @@ impl Controller {
         }
         self.watchdog.unwatch(app_id);
 
-        if let Some(job) = self.jobs.lock().unwrap().remove(app_id) {
-            job.kill_all();
-        } else if let Some(app) = self
+        let app = self
             .config
             .lock()
             .unwrap()
             .apps
             .iter()
             .find(|a| a.id == app_id)
-            .cloned()
-        {
-            kill_app(&app, DEFAULT_GRACE_SECS);
+            .cloned();
+
+        if let Some(job) = self.jobs.lock().unwrap().remove(app_id) {
+            job.kill_all();
+        }
+        if let Some(ref app) = app {
+            let grace = if app.force_kill_on_stop { 0.0 } else { DEFAULT_GRACE_SECS };
+            process_killer::kill_by_exe_path(&app.exe_path, grace);
         }
 
         if let Some(app) = self

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -282,14 +282,14 @@ impl Controller {
 
         // Monitor callback — spawns threads so the monitor is never blocked
         let ctrl_mon = Arc::clone(&ctrl);
-        let process_name = crate::monitor::process_name_for(&trigger).to_string();
+
         let monitor = Monitor::start(trigger, poll_interval, move |event| match event {
             MonitorEvent::Started => {
                 iracing_online.store(true, Ordering::Relaxed);
                 on_status(true);
                 let c = Arc::clone(&ctrl_mon);
                 c.sink
-                    .push(LogKind::IracingStart, None, format!("{process_name} started"));
+                    .push(LogKind::IracingStart, Some("iRacing".into()), "started".into());
                 thread::spawn(move || c.launch_active_apps());
             }
             MonitorEvent::Stopped => {
@@ -297,7 +297,7 @@ impl Controller {
                 on_status(false);
                 let c = Arc::clone(&ctrl_mon);
                 c.sink
-                    .push(LogKind::IracingStop, None, format!("{process_name} stopped"));
+                    .push(LogKind::IracingStop, Some("iRacing".into()), "stopped".into());
                 if auto_stop.load(Ordering::Relaxed) {
                     thread::spawn(move || c.kill_all_running());
                 }

--- a/src-tauri/src/controller.rs
+++ b/src-tauri/src/controller.rs
@@ -21,6 +21,7 @@ pub enum LogKind {
     Launch,
     Stop,
     Crashed,
+    Restarted,
     IracingStart,
     IracingStop,
 }
@@ -32,6 +33,9 @@ pub struct LogEntry {
     pub kind: LogKind,
     pub app: Option<String>,
     pub msg: String,
+    pub pid: Option<u32>,
+    pub restart_count: Option<u32>,
+    pub max_restarts: Option<u32>,
 }
 
 pub struct LogSink {
@@ -41,7 +45,7 @@ pub struct LogSink {
 }
 
 impl LogSink {
-    fn push(&self, kind: LogKind, app: Option<String>, msg: String) {
+    fn push(&self, kind: LogKind, app: Option<String>, msg: String, pid: Option<u32>, restart_count: Option<u32>, max_restarts: Option<u32>) {
         let s = self.seq.fetch_add(1, Ordering::Relaxed);
         let ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -53,6 +57,9 @@ impl LogSink {
             kind,
             app,
             msg,
+            pid,
+            restart_count,
+            max_restarts,
         };
         let mut log = self.log.lock().unwrap();
         log.push(entry.clone());
@@ -256,10 +263,6 @@ impl Controller {
                             .lock()
                             .unwrap()
                             .on_app_restarted(&app_id, new_pid, attempt);
-                    }
-                    WatchdogEvent::GaveUp { app_id } | WatchdogEvent::RestartFailed { app_id } => {
-                        let restart_count = ctrl_wd.logic.lock().unwrap().on_app_gave_up(&app_id);
-                        // Log the crash
                         if let Some(app) = ctrl_wd
                             .config
                             .lock()
@@ -270,9 +273,40 @@ impl Controller {
                             .cloned()
                         {
                             sink_wd.push(
+                                LogKind::Restarted,
+                                Some(app.name.clone()),
+                                String::new(),
+                                Some(new_pid),
+                                Some(attempt),
+                                Some(app.max_restart_attempts),
+                            );
+                        }
+                    }
+                    WatchdogEvent::GaveUp { app_id, restart_count }
+                    | WatchdogEvent::RestartFailed { app_id, restart_count } => {
+                        ctrl_wd.logic.lock().unwrap().on_app_gave_up(&app_id);
+                        if let Some(app) = ctrl_wd
+                            .config
+                            .lock()
+                            .unwrap()
+                            .apps
+                            .iter()
+                            .find(|a| a.id == app_id)
+                            .cloned()
+                        {
+                            // Include restart details only when restart_on_crash is enabled.
+                            let (rc, mr) = if app.restart_on_crash {
+                                (Some(restart_count), Some(app.max_restart_attempts))
+                            } else {
+                                (None, None)
+                            };
+                            sink_wd.push(
                                 LogKind::Crashed,
                                 Some(app.name.clone()),
-                                format!("crashed (restart {restart_count}/{})", app.max_restart_attempts),
+                                String::new(),
+                                None,
+                                rc,
+                                mr,
                             );
                         }
                     }
@@ -289,7 +323,7 @@ impl Controller {
                 on_status(true);
                 let c = Arc::clone(&ctrl_mon);
                 c.sink
-                    .push(LogKind::IracingStart, Some("iRacing".into()), "started".into());
+                    .push(LogKind::IracingStart, Some("iRacing".into()), String::new(), None, None, None);
                 thread::spawn(move || c.launch_active_apps());
             }
             MonitorEvent::Stopped => {
@@ -297,7 +331,7 @@ impl Controller {
                 on_status(false);
                 let c = Arc::clone(&ctrl_mon);
                 c.sink
-                    .push(LogKind::IracingStop, Some("iRacing".into()), "stopped".into());
+                    .push(LogKind::IracingStop, Some("iRacing".into()), String::new(), None, None, None);
                 if auto_stop.load(Ordering::Relaxed) {
                     thread::spawn(move || c.kill_all_running());
                 }
@@ -386,7 +420,10 @@ impl Controller {
                         sink.push(
                             LogKind::Launch,
                             Some(app.name.clone()),
-                            format!("started (pid {pid})"),
+                            String::new(),
+                            Some(pid),
+                            None,
+                            None,
                         );
                     }
                     Err(e) => {
@@ -395,7 +432,10 @@ impl Controller {
                         sink.push(
                             LogKind::Crashed,
                             Some(app.name.clone()),
-                            format!("failed to start: {e}"),
+                            e.to_string(),
+                            None,
+                            None,
+                            None,
                         );
                     }
                 }
@@ -458,7 +498,7 @@ impl Controller {
                     println!("[controller] killing '{}' via exe_path fallback", app.name);
                     let grace = if app.force_kill_on_stop { 0.0 } else { DEFAULT_GRACE_SECS };
                     process_killer::kill_by_exe_path(&app.exe_path, grace);
-                    sink.push(LogKind::Stop, Some(app.name.clone()), "stopped".into());
+                    sink.push(LogKind::Stop, Some(app.name.clone()), String::new(), None, None, None);
                 }))
             })
             .collect();
@@ -564,7 +604,7 @@ impl Controller {
             .find(|a| a.id == app_id)
         {
             self.sink
-                .push(LogKind::Stop, Some(app.name.clone()), String::new());
+                .push(LogKind::Stop, Some(app.name.clone()), String::new(), None, None, None);
         }
 
         self.logic.lock().unwrap().on_app_stopped(app_id);

--- a/src-tauri/src/launcher.rs
+++ b/src-tauri/src/launcher.rs
@@ -211,12 +211,7 @@ pub fn resolve_real_pid_impl(
     find_by_name: impl Fn(&str) -> Vec<u32>,
     find_by_exe_path: impl Fn(&str) -> Vec<u32>,
 ) -> u32 {
-    if is_alive(stub_pid) {
-        #[cfg(debug_assertions)]
-        println!("[launcher] resolve: stub_pid={stub_pid} still alive");
-        return stub_pid;
-    }
-
+    // 1. Prefer track_process_name if configured.
     if let Some(name) = track_name {
         let pids = find_by_name(name);
         if let Some(&pid) = pids.first() {
@@ -226,11 +221,31 @@ pub fn resolve_real_pid_impl(
         }
     }
 
+    // 2. Search by exe_path (handles Squirrel versioned subdirs).
     let pids = find_by_exe_path(exe_path);
     if let Some(&pid) = pids.first() {
+        if pid != stub_pid {
+            #[cfg(debug_assertions)]
+            println!("[launcher] resolve: found by exe_path='{exe_path}' pid={pid} (different from stub)");
+            return pid;
+        }
+        // PID matches stub and stub is alive → no handoff, use stub.
+        if is_alive(stub_pid) {
+            #[cfg(debug_assertions)]
+            println!("[launcher] resolve: stub_pid={stub_pid} still alive, no handoff detected");
+            return stub_pid;
+        }
+        // PID matches stub but stub is dead → return it anyway (last resort).
         #[cfg(debug_assertions)]
-        println!("[launcher] resolve: found by exe_path='{exe_path}' pid={pid}");
-        return pid;
+        println!("[launcher] resolve: stub_pid={stub_pid} dead, no real process found");
+        return stub_pid;
+    }
+
+    // 3. Fallback: stub is alive but no real process found yet.
+    if is_alive(stub_pid) {
+        #[cfg(debug_assertions)]
+        println!("[launcher] resolve: stub_pid={stub_pid} still alive (no handoff yet)");
+        return stub_pid;
     }
 
     #[cfg(debug_assertions)]

--- a/src-tauri/src/process_killer.rs
+++ b/src-tauri/src/process_killer.rs
@@ -314,3 +314,86 @@ pub fn graceful_kill(pid: u32, grace_secs: f64) {
         force_kill(pid);
     }
 }
+
+// ── Windows Job Objects ──────────────────────────────────────────────────────
+
+/// A Windows Job Object that automatically kills all assigned processes
+/// when the handle is closed (KILL_ON_JOB_CLOSE).
+pub struct ProcessJob {
+    handle: windows::Win32::Foundation::HANDLE,
+}
+
+// Job Object handles are thread-safe in Windows; these are just opaque
+// pointers and all Win32 Job Object APIs are safe to call concurrently.
+unsafe impl Send for ProcessJob {}
+unsafe impl Sync for ProcessJob {}
+
+impl ProcessJob {
+    /// Creates a new Job Object configured to kill all processes on close.
+    pub fn new() -> Result<Self, String> {
+        use windows::Win32::System::JobObjects::{
+            CreateJobObjectW, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, SetInformationJobObject,
+        };
+        use windows::Win32::System::JobObjects::JobObjectExtendedLimitInformation;
+
+        let handle = unsafe {
+            CreateJobObjectW(None, None).map_err(|e| e.to_string())?
+        };
+
+        let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        info.BasicLimitInformation.LimitFlags =
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        unsafe {
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const _,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+            .map_err(|e| e.to_string())?;
+        }
+
+        Ok(Self { handle })
+    }
+
+    /// Assigns a running process (by PID) to this Job Object.
+    pub fn assign(&self, pid: u32) -> Result<(), String> {
+        use windows::Win32::Foundation::CloseHandle;
+        use windows::Win32::System::JobObjects::AssignProcessToJobObject;
+        use windows::Win32::System::Threading::{OpenProcess, PROCESS_TERMINATE};
+
+        let proc_handle = unsafe {
+            match OpenProcess(PROCESS_TERMINATE, false, pid) {
+                Ok(h) => h,
+                Err(_) => return Err(format!("failed to open process {pid}")),
+            }
+        };
+
+        let result = unsafe {
+            AssignProcessToJobObject(self.handle, proc_handle)
+                .map_err(|e| e.to_string())
+        };
+
+        unsafe {
+            let _ = CloseHandle(proc_handle);
+        }
+
+        result
+    }
+
+    /// Closes the Job handle, causing Windows to terminate all processes in the Job.
+    pub fn kill_all(self) {
+        // Drop will close the handle
+    }
+}
+
+impl Drop for ProcessJob {
+    fn drop(&mut self) {
+        use windows::Win32::Foundation::CloseHandle;
+        unsafe {
+            let _ = CloseHandle(self.handle);
+        }
+    }
+}

--- a/src-tauri/src/process_killer.rs
+++ b/src-tauri/src/process_killer.rs
@@ -86,9 +86,22 @@ pub fn kill_by_exe_path(exe_path: &str, grace_secs: f64) {
 }
 
 /// Kills all processes matching `exe_path`, plus their entire child process trees.
+/// Also kills every process with the same image name (e.g. G Hub spawns multiple
+/// independent lghub.exe instances) via `taskkill /F /IM`.
 pub fn kill_tree_by_exe_path(exe_path: &str, grace_secs: f64) {
-    for pid in find_pids_by_exe_path(exe_path) {
-        kill_tree(pid, grace_secs);
+    let pids: Vec<u32> = find_pids_by_exe_path(exe_path);
+
+    for pid in &pids {
+        kill_tree(*pid, grace_secs);
+    }
+
+    // Fallback: some apps (e.g. G Hub) spawn sibling processes that are not
+    // children of the tracked PID. taskkill /F /IM catches every process with
+    // the same executable name regardless of hierarchy.
+    if let Some(file_name) = Path::new(exe_path).file_name().and_then(|n| n.to_str()) {
+        let _ = std::process::Command::new("taskkill")
+            .args(["/F", "/IM", file_name])
+            .output();
     }
 }
 

--- a/src-tauri/src/process_killer.rs
+++ b/src-tauri/src/process_killer.rs
@@ -258,12 +258,22 @@ pub fn graceful_kill(pid: u32, grace_secs: f64) {
         return;
     }
 
+    // If the process has no visible windows it is likely already minimised
+    // to the system tray. Sending WM_CLOSE in that state just gives the app
+    // a chance to show a tray notification instead of exiting. Force-kill
+    // immediately in that case.
+    if !has_visible_windows(pid) {
+        #[cfg(debug_assertions)]
+        println!("[process_killer] pid={pid} has no visible windows — skipping WM_CLOSE, force killing");
+        force_kill(pid);
+        return;
+    }
+
     send_wm_close(pid);
 
-    // Fast-fail: some apps (e.g. Trading Paints) intercept WM_CLOSE and
-    // minimise to tray, firing a notification. If the process is still alive
-    // but has no visible windows after a brief wait, force-kill immediately.
-    std::thread::sleep(Duration::from_millis(250));
+    // Fast-fail: some apps intercept WM_CLOSE and minimise to tray. If the
+    // window disappears but the process is still alive, force-kill immediately.
+    std::thread::sleep(Duration::from_millis(100));
     if is_pid_alive(pid) && !has_visible_windows(pid) {
         #[cfg(debug_assertions)]
         println!("[process_killer] pid={pid} alive but no visible windows after WM_CLOSE — force killing");

--- a/src-tauri/src/process_killer.rs
+++ b/src-tauri/src/process_killer.rs
@@ -362,18 +362,19 @@ impl ProcessJob {
     pub fn assign(&self, pid: u32) -> Result<(), String> {
         use windows::Win32::Foundation::CloseHandle;
         use windows::Win32::System::JobObjects::AssignProcessToJobObject;
-        use windows::Win32::System::Threading::{OpenProcess, PROCESS_TERMINATE};
+        use windows::Win32::System::Threading::{OpenProcess, PROCESS_TERMINATE, PROCESS_SET_QUOTA};
 
+        let access = PROCESS_TERMINATE | PROCESS_SET_QUOTA;
         let proc_handle = unsafe {
-            match OpenProcess(PROCESS_TERMINATE, false, pid) {
+            match OpenProcess(access, false, pid) {
                 Ok(h) => h,
-                Err(_) => return Err(format!("failed to open process {pid}")),
+                Err(e) => return Err(format!("failed to open process {pid}: {e}")),
             }
         };
 
         let result = unsafe {
             AssignProcessToJobObject(self.handle, proc_handle)
-                .map_err(|e| e.to_string())
+                .map_err(|e| format!("AssignProcessToJobObject failed for pid {pid}: {e}"))
         };
 
         unsafe {
@@ -385,6 +386,8 @@ impl ProcessJob {
 
     /// Closes the Job handle, causing Windows to terminate all processes in the Job.
     pub fn kill_all(self) {
+        #[cfg(debug_assertions)]
+        println!("[process_killer] closing job handle — all assigned processes will be terminated");
         // Drop will close the handle
     }
 }

--- a/src-tauri/src/process_killer.rs
+++ b/src-tauri/src/process_killer.rs
@@ -85,9 +85,17 @@ pub fn kill_by_exe_path(exe_path: &str, grace_secs: f64) {
     }
 }
 
+/// Returns the prefix of an executable name (before the first separator).
+///
+/// "lghub_system_tray.exe" → "lghub"
+/// "SimHub.exe"            → "SimHub"
+fn exe_prefix(name: &str) -> Option<&str> {
+    name.split(|c: char| c == '_' || c == '-').next()
+}
+
 /// Kills all processes matching `exe_path`, plus their entire child process trees.
-/// Also kills every process with the same image name (e.g. G Hub spawns multiple
-/// independent lghub.exe instances) via `taskkill /F /IM`.
+/// Also kills every process with the same prefix (e.g. G Hub spawns multiple
+/// independent lghub_*.exe instances) via `taskkill /F /FI "IMAGENAME eq prefix*"`.
 pub fn kill_tree_by_exe_path(exe_path: &str, grace_secs: f64) {
     let pids: Vec<u32> = find_pids_by_exe_path(exe_path);
 
@@ -96,12 +104,19 @@ pub fn kill_tree_by_exe_path(exe_path: &str, grace_secs: f64) {
     }
 
     // Fallback: some apps (e.g. G Hub) spawn sibling processes that are not
-    // children of the tracked PID. taskkill /F /IM catches every process with
-    // the same executable name regardless of hierarchy.
+    // children of the tracked PID. Use a wildcard filter to catch every process
+    // whose image name starts with the same prefix (e.g. lghub*).
     if let Some(file_name) = Path::new(exe_path).file_name().and_then(|n| n.to_str()) {
         let _ = std::process::Command::new("taskkill")
             .args(["/F", "/IM", file_name])
             .output();
+
+        if let Some(prefix) = exe_prefix(file_name) {
+            let filter = format!("IMAGENAME eq {prefix}*");
+            let _ = std::process::Command::new("taskkill")
+                .args(["/F", "/FI", &filter])
+                .output();
+        }
     }
 }
 

--- a/src-tauri/src/process_killer.rs
+++ b/src-tauri/src/process_killer.rs
@@ -215,6 +215,41 @@ pub fn force_kill(pid: u32) {
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
+/// Returns true if the given PID owns any visible top-level window.
+pub fn has_visible_windows(pid: u32) -> bool {
+    use windows::Win32::Foundation::{BOOL, HWND, LPARAM};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetWindowThreadProcessId, IsWindowVisible,
+    };
+
+    struct Context {
+        target_pid: u32,
+        found: bool,
+    }
+
+    let mut ctx = Context {
+        target_pid: pid,
+        found: false,
+    };
+
+    unsafe extern "system" fn enum_cb(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let ctx = &mut *(lparam.0 as *mut Context);
+        let mut window_pid: u32 = 0;
+        unsafe { GetWindowThreadProcessId(hwnd, Some(&mut window_pid)) };
+        if window_pid == ctx.target_pid && unsafe { IsWindowVisible(hwnd).as_bool() } {
+            ctx.found = true;
+            return BOOL(0); // stop enumeration
+        }
+        BOOL(1)
+    }
+
+    unsafe {
+        let _ = EnumWindows(Some(enum_cb), LPARAM(&mut ctx as *mut _ as isize));
+    }
+
+    ctx.found
+}
+
 /// Graceful shutdown: WM_CLOSE → grace period → force kill.
 /// When `grace_secs` is 0, skips straight to force kill.
 pub fn graceful_kill(pid: u32, grace_secs: f64) {
@@ -224,6 +259,17 @@ pub fn graceful_kill(pid: u32, grace_secs: f64) {
     }
 
     send_wm_close(pid);
+
+    // Fast-fail: some apps (e.g. Trading Paints) intercept WM_CLOSE and
+    // minimise to tray, firing a notification. If the process is still alive
+    // but has no visible windows after a brief wait, force-kill immediately.
+    std::thread::sleep(Duration::from_millis(250));
+    if is_pid_alive(pid) && !has_visible_windows(pid) {
+        #[cfg(debug_assertions)]
+        println!("[process_killer] pid={pid} alive but no visible windows after WM_CLOSE — force killing");
+        force_kill(pid);
+        return;
+    }
 
     let grace = Duration::from_secs_f64(grace_secs);
     if !wait_for_exit(pid, grace) {

--- a/src-tauri/src/watchdog.rs
+++ b/src-tauri/src/watchdog.rs
@@ -4,8 +4,21 @@ use std::thread;
 use std::time::Duration;
 
 use crate::models::ManagedApp;
+use crate::process_killer;
 
 const POLL_INTERVAL_MS: u64 = 2000;
+
+/// Attempts to find the current PID of a running app when the tracked PID
+/// no longer matches (e.g. Squirrel stub died, app self-restarted).
+/// Returns the new PID if a living process is found, otherwise None.
+fn reconcile_pid(app: &ManagedApp) -> Option<u32> {
+    let pids = if let Some(ref name) = app.track_process_name {
+        process_killer::find_pids_by_name(name)
+    } else {
+        process_killer::find_pids_by_exe_path(&app.exe_path)
+    };
+    pids.into_iter().find(|&pid| process_killer::is_pid_alive(pid))
+}
 
 // ── Events ────────────────────────────────────────────────────────────────────
 
@@ -18,9 +31,15 @@ pub enum WatchdogEvent {
         attempt: u32,
     },
     /// Process crashed and all restart attempts were exhausted (or restart disabled).
-    GaveUp { app_id: String },
+    GaveUp {
+        app_id: String,
+        restart_count: u32,
+    },
     /// Relaunch after crash failed (exe not found, spawn error, etc.).
-    RestartFailed { app_id: String },
+    RestartFailed {
+        app_id: String,
+        restart_count: u32,
+    },
 }
 
 // ── Pure tick logic ───────────────────────────────────────────────────────────
@@ -110,29 +129,86 @@ impl Watchdog {
                         entries_bg.lock().unwrap().remove(&id);
                     }
                     TickAction::GiveUp => {
-                        entries_bg.lock().unwrap().remove(&id);
-                        let _ = tx.send(WatchdogEvent::GaveUp { app_id: id });
-                    }
-                    TickAction::Restart => match crate::launcher::launch(&entry.app) {
-                        Ok(stub_pid) => {
-                            let real_pid = crate::launcher::resolve_real_pid(stub_pid, &entry.app);
-                            let attempt = entry.restart_count + 1;
-                            let mut map = entries_bg.lock().unwrap();
-                            if let Some(e) = map.get_mut(&id) {
-                                e.pid = real_pid;
-                                e.restart_count = attempt;
+                        // Re-check current state inside the mutex — unwatch may have
+                        // been called between the clone above and now.
+                        {
+                            let map = entries_bg.lock().unwrap();
+                            if let Some(e) = map.get(&id) {
+                                if e.stopping {
+                                    drop(map);
+                                    entries_bg.lock().unwrap().remove(&id);
+                                    continue;
+                                }
                             }
-                            let _ = tx.send(WatchdogEvent::Restarted {
-                                app_id: id,
-                                new_pid: real_pid,
-                                attempt,
-                            });
                         }
-                        Err(_) => {
-                            entries_bg.lock().unwrap().remove(&id);
-                            let _ = tx.send(WatchdogEvent::RestartFailed { app_id: id });
+                        // Before giving up, try to reconcile: the app may have
+                        // self-restarted or done a Squirrel handoff to a new PID.
+                        if let Some(new_pid) = reconcile_pid(&entry.app) {
+                            if new_pid != entry.pid {
+                                #[cfg(debug_assertions)]
+                                println!("[watchdog] reconciled '{app}' pid {old} → {new}",
+                                    app = entry.app.name, old = entry.pid, new = new_pid);
+                                let mut map = entries_bg.lock().unwrap();
+                                if let Some(e) = map.get_mut(&id) {
+                                    e.pid = new_pid;
+                                }
+                                continue;
+                            }
                         }
-                    },
+                        let rc = entry.restart_count;
+                        entries_bg.lock().unwrap().remove(&id);
+                        let _ = tx.send(WatchdogEvent::GaveUp { app_id: id, restart_count: rc });
+                    }
+                    TickAction::Restart => {
+                        // Re-check current state inside the mutex — unwatch may have
+                        // been called between the clone above and now.
+                        {
+                            let map = entries_bg.lock().unwrap();
+                            if let Some(e) = map.get(&id) {
+                                if e.stopping {
+                                    drop(map);
+                                    entries_bg.lock().unwrap().remove(&id);
+                                    continue;
+                                }
+                            }
+                        }
+                        // Same reconciliation check before attempting restart.
+                        if let Some(new_pid) = reconcile_pid(&entry.app) {
+                            if new_pid != entry.pid {
+                                #[cfg(debug_assertions)]
+                                println!("[watchdog] reconciled '{app}' pid {old} → {new}",
+                                    app = entry.app.name, old = entry.pid, new = new_pid);
+                                let mut map = entries_bg.lock().unwrap();
+                                if let Some(e) = map.get_mut(&id) {
+                                    e.pid = new_pid;
+                                    // Reset restart count — the app is alive, just under a new PID.
+                                    e.restart_count = 0;
+                                }
+                                continue;
+                            }
+                        }
+                        match crate::launcher::launch(&entry.app) {
+                            Ok(stub_pid) => {
+                                let real_pid = crate::launcher::resolve_real_pid(stub_pid, &entry.app);
+                                let attempt = entry.restart_count + 1;
+                                let mut map = entries_bg.lock().unwrap();
+                                if let Some(e) = map.get_mut(&id) {
+                                    e.pid = real_pid;
+                                    e.restart_count = attempt;
+                                }
+                                let _ = tx.send(WatchdogEvent::Restarted {
+                                    app_id: id,
+                                    new_pid: real_pid,
+                                    attempt,
+                                });
+                            }
+                            Err(_) => {
+                                let rc = entry.restart_count;
+                                entries_bg.lock().unwrap().remove(&id);
+                                let _ = tx.send(WatchdogEvent::RestartFailed { app_id: id, restart_count: rc });
+                            }
+                        }
+                    }
                 }
             }
         });

--- a/src-tauri/tests/launcher_tests.rs
+++ b/src-tauri/tests/launcher_tests.rs
@@ -173,6 +173,21 @@ fn should_return_stub_pid_when_process_is_still_alive() {
 }
 
 #[test]
+fn should_prefer_real_pid_when_stub_is_alive_but_handoff_detected() {
+    // Squirrel scenario: stub is alive temporarily, but exe_path search
+    // finds the real process in a versioned subdirectory.
+    let pid = resolve_real_pid_impl(
+        1234,
+        None,
+        "C:/Kapps/Kapps.exe",
+        |_| true,       // stub is alive
+        |_| vec![],     // no track name
+        |_| vec![5678], // real process found via Squirrel subdir
+    );
+    assert_eq!(pid, 5678, "should return real PID, not the temporary stub");
+}
+
+#[test]
 fn should_find_by_track_name_when_stub_dies() {
     let pid = resolve_real_pid_impl(
         1234,

--- a/src-tauri/tests/process_killer_tests.rs
+++ b/src-tauri/tests/process_killer_tests.rs
@@ -1,6 +1,6 @@
 use pitlane_lib::process_killer::{
     exe_path_matches, force_kill, graceful_kill, has_visible_windows, is_pid_alive,
-    needs_graceful_close,
+    needs_graceful_close, ProcessJob,
 };
 use std::time::Duration;
 
@@ -162,4 +162,96 @@ fn manual_should_force_kill_winver() {
 
     assert!(!is_pid_alive(pid), "winver should be dead after force_kill");
     println!("[killer integration] ✓ process killed");
+}
+
+
+// ── ProcessJob ───────────────────────────────────────────────────────────────
+
+#[test]
+fn should_create_job_object() {
+    let job = ProcessJob::new();
+    assert!(job.is_ok(), "ProcessJob::new should succeed");
+}
+
+#[test]
+fn should_not_panic_when_assigning_nonexistent_pid() {
+    let job = ProcessJob::new().unwrap();
+    // PID 0 and u32::MAX are never valid
+    assert!(job.assign(0).is_err());
+    assert!(job.assign(u32::MAX).is_err());
+}
+
+fn fixture_path(name: &str) -> String {
+    let dir = env!("CARGO_MANIFEST_DIR");
+    format!("{dir}\\target\\debug\\{name}.exe")
+}
+
+#[test]
+#[ignore]
+fn manual_should_kill_assigned_process_when_job_dropped() {
+    use std::process::Command;
+    use std::time::Duration;
+
+    let path = fixture_path("fixture-dummy");
+    let child = Command::new(&path).spawn().expect("failed to spawn fixture-dummy");
+    let pid = child.id();
+    println!("[job integration] spawned dummy PID: {pid}");
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    let job = ProcessJob::new().expect("failed to create job");
+    job.assign(pid).expect("failed to assign process to job");
+    println!("[job integration] assigned PID {pid} to job");
+
+    // Drop the job — this should terminate the process
+    drop(job);
+    println!("[job integration] dropped job handle");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    assert!(!is_pid_alive(pid), "dummy should be dead after job handle closed");
+    println!("[job integration] ✓ process killed by job close");
+}
+
+#[test]
+#[ignore]
+fn manual_should_kill_child_processes_inherited_from_job() {
+    use std::process::Command;
+    use std::time::Duration;
+
+    // fixture-stub spawns fixture-dummy as a child
+    let stub_path = fixture_path("fixture-stub");
+    let child = Command::new(&stub_path).spawn().expect("failed to spawn fixture-stub");
+    let stub_pid = child.id();
+    println!("[job integration] spawned stub PID: {stub_pid}");
+
+    // Give fixture-stub time to spawn fixture-dummy
+    std::thread::sleep(Duration::from_millis(500));
+
+    let job = ProcessJob::new().expect("failed to create job");
+    job.assign(stub_pid).expect("failed to assign stub to job");
+    println!("[job integration] assigned stub PID {stub_pid} to job");
+
+    // Find the child PID spawned by stub
+    let child_pid = pitlane_lib::process_killer::find_pids_by_name("fixture-dummy.exe")
+        .into_iter()
+        .find(|&p| p != stub_pid);
+
+    if let Some(cp) = child_pid {
+        println!("[job integration] found child PID: {cp}");
+    }
+
+    drop(job);
+    println!("[job integration] dropped job handle");
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    assert!(!is_pid_alive(stub_pid), "stub should be dead after job close");
+    if let Some(cp) = child_pid {
+        assert!(
+            !is_pid_alive(cp),
+            "child dummy should also be dead after job close"
+        );
+    }
+    println!("[job integration] ✓ stub and child killed by job close");
 }

--- a/src-tauri/tests/process_killer_tests.rs
+++ b/src-tauri/tests/process_killer_tests.rs
@@ -1,5 +1,6 @@
 use pitlane_lib::process_killer::{
-    exe_path_matches, force_kill, graceful_kill, is_pid_alive, needs_graceful_close,
+    exe_path_matches, force_kill, graceful_kill, has_visible_windows, is_pid_alive,
+    needs_graceful_close,
 };
 use std::time::Duration;
 
@@ -88,6 +89,29 @@ fn should_not_panic_when_force_killing_nonexistent_pid() {
 fn should_not_panic_when_graceful_killing_nonexistent_pid() {
     graceful_kill(0, 0.0);
     graceful_kill(u32::MAX, 5.0);
+}
+
+// ── has_visible_windows ──────────────────────────────────────────────────────
+
+#[test]
+fn should_return_false_for_nonexistent_pid() {
+    assert!(!has_visible_windows(0));
+    assert!(!has_visible_windows(u32::MAX));
+}
+
+#[test]
+fn should_return_false_for_process_without_windows() {
+    // Spawn a windowless console fixture
+    let child = std::process::Command::new("cmd")
+        .args(["/C", "timeout /t 3 > nul"])
+        .spawn()
+        .expect("failed to spawn cmd");
+    let pid = child.id();
+
+    std::thread::sleep(Duration::from_millis(100));
+    assert!(!has_visible_windows(pid), "cmd should have no visible windows");
+
+    force_kill(pid);
 }
 
 // ── Manual integration tests (require a real spawned process) ────────────────

--- a/src/__tests__/ui/ActivityRow.test.tsx
+++ b/src/__tests__/ui/ActivityRow.test.tsx
@@ -40,4 +40,11 @@ describe('ActivityRow', () => {
         const icon = screen.getByRole('img', { name: 'ERROR' })
         expect(icon.getAttribute('class')).toContain('text-danger')
     })
+
+    it('applies crashed variant with danger color', () => {
+        render(<ActivityRow time="10:24:45" event="CRASHED" variant="crashed" />)
+
+        const icon = screen.getByRole('img', { name: 'CRASHED' })
+        expect(icon.getAttribute('class')).toContain('text-danger')
+    })
 })

--- a/src/components/screens/CommandCenterScreen.tsx
+++ b/src/components/screens/CommandCenterScreen.tsx
@@ -10,7 +10,7 @@ import { useAppIconUrls } from './command-center/useAppIconUrls'
 export { computeAppSummary, computeReadiness } from '@/lib/command-center'
 export type { AppSummary, Readiness } from '@/lib/command-center'
 
-const RECENT_COUNT = 6
+const RECENT_COUNT = 30
 
 interface CommandCenterScreenProps {
     onAddApp?: () => void

--- a/src/components/screens/LogScreen.tsx
+++ b/src/components/screens/LogScreen.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/cn'
 import { useLog } from '@/hooks'
 import type { LogKind } from '@/lib/api'
+import { formatLogMessage } from '@/lib/command-center'
 import { ScreenHeader } from '@/components/layout'
 import { EmptyState } from '@/components/ui'
 
@@ -11,6 +12,7 @@ const kindStyle: Record<LogKind, string> = {
     launch: 'text-success',
     stop: 'text-warning',
     crashed: 'text-danger',
+    restarted: 'text-warning',
     iracing_start: 'text-accent',
     iracing_stop: 'text-accent/75',
 }
@@ -19,6 +21,7 @@ const kindLabel: Record<LogKind, string> = {
     launch: 'STARTED',
     stop: 'STOPPED',
     crashed: 'CRASHED',
+    restarted: 'RESTART',
     iracing_start: 'iRACING ▶',
     iracing_stop: 'iRACING ■',
 }
@@ -47,35 +50,31 @@ export function LogScreen() {
                 {entries.length === 0 ? (
                     <EmptyState icon={ScrollText} message={t('log.empty')} />
                 ) : (
-                    entries.map((entry) => (
-                        <div
-                            key={entry.seq}
-                            className={cn(
-                                'flex items-start gap-2 py-0.5 px-1 rounded',
-                                (entry.kind === 'iracing_start' || entry.kind === 'iracing_stop') &&
-                                    'bg-accent/5',
-                            )}
-                        >
-                            <span className="text-text-muted shrink-0 w-16">
-                                {formatTime(entry.timestamp_ms)}
-                            </span>
-                            <span
-                                className={cn('shrink-0 w-14 font-semibold', kindStyle[entry.kind])}
+                    <div className="grid grid-cols-[4rem_5.5rem_7.5rem_1fr] gap-2">
+                        {entries.map((entry) => (
+                            <div
+                                key={entry.seq}
+                                className={cn(
+                                    'col-span-4 grid grid-cols-subgrid items-start py-0.5 px-1 rounded',
+                                    (entry.kind === 'iracing_start' || entry.kind === 'iracing_stop') &&
+                                        'bg-accent/5',
+                                )}
                             >
-                                {kindLabel[entry.kind]}
-                            </span>
-                            {entry.app && (
-                                <span className="text-text-secondary shrink-0 max-w-28 truncate">
-                                    {entry.app}
+                                <span className="text-text-muted">
+                                    {formatTime(entry.timestamp_ms)}
                                 </span>
-                            )}
-                            {entry.msg && (
-                                <span className={cn('text-text-muted', kindStyle[entry.kind])}>
-                                    {entry.msg}
+                                <span className={cn('font-semibold', kindStyle[entry.kind])}>
+                                    {kindLabel[entry.kind]}
                                 </span>
-                            )}
-                        </div>
-                    ))
+                                <span className="text-text-secondary truncate">
+                                    {entry.app ?? ''}
+                                </span>
+                                <span className={cn('truncate', kindStyle[entry.kind])}>
+                                    {formatLogMessage(entry)}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
                 )}
                 <div ref={bottomRef} />
             </div>

--- a/src/components/screens/LogScreen.tsx
+++ b/src/components/screens/LogScreen.tsx
@@ -10,13 +10,15 @@ import { EmptyState } from '@/components/ui'
 const kindStyle: Record<LogKind, string> = {
     launch: 'text-success',
     stop: 'text-warning',
+    crashed: 'text-danger',
     iracing_start: 'text-accent',
     iracing_stop: 'text-accent/75',
 }
 
 const kindLabel: Record<LogKind, string> = {
-    launch: 'LAUNCH',
-    stop: 'STOP',
+    launch: 'STARTED',
+    stop: 'STOPPED',
+    crashed: 'CRASHED',
     iracing_start: 'iRACING ▶',
     iracing_stop: 'iRACING ■',
 }

--- a/src/components/screens/LogScreen.tsx
+++ b/src/components/screens/LogScreen.tsx
@@ -69,7 +69,11 @@ export function LogScreen() {
                                     {entry.app}
                                 </span>
                             )}
-                            {entry.msg && <span className="text-text-muted">{entry.msg}</span>}
+                            {entry.msg && (
+                                <span className={cn('text-text-muted', kindStyle[entry.kind])}>
+                                    {entry.msg}
+                                </span>
+                            )}
                         </div>
                     ))
                 )}

--- a/src/components/screens/command-center/RecentActivityPanel.tsx
+++ b/src/components/screens/command-center/RecentActivityPanel.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { ActivityRow, Button, Panel } from '@/components/ui'
 import { cn } from '@/lib/cn'
 import type { LogEntry } from '@/lib/api'
-import { formatTime, KIND_VARIANT } from '@/lib/command-center'
+import { formatTime, formatLogMessage, KIND_VARIANT } from '@/lib/command-center'
 
 interface RecentActivityPanelProps {
     entries: LogEntry[]
@@ -68,7 +68,7 @@ export function RecentActivityPanel({ entries }: RecentActivityPanelProps) {
                             event={t(`command.log_events.${entry.kind}`)}
                             variant={KIND_VARIANT[entry.kind]}
                             source={entry.app ?? undefined}
-                            message={entry.msg}
+                            message={formatLogMessage(entry)}
                         />
                     ))
                 ) : (

--- a/src/components/screens/command-center/RecentActivityPanel.tsx
+++ b/src/components/screens/command-center/RecentActivityPanel.tsx
@@ -56,7 +56,10 @@ export function RecentActivityPanel({ entries }: RecentActivityPanelProps) {
                     </Button>
                 </div>
             </div>
-            <div id="recent-activity-content" className="flex flex-1 flex-col bg-base">
+            <div
+                id="recent-activity-content"
+                className="flex flex-1 flex-col overflow-y-auto bg-base"
+            >
                 {entries.length > 0 ? (
                     entries.map((entry) => (
                         <ActivityRow

--- a/src/components/ui/ActivityRow.tsx
+++ b/src/components/ui/ActivityRow.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/cn'
 const VARIANT_CONFIG = {
     launch: { icon: CheckCircle2, className: 'text-success' },
     stop: { icon: MinusCircle, className: 'text-text-muted' },
+    crashed: { icon: AlertTriangle, className: 'text-danger' },
     iracing: { icon: CheckCircle2, className: 'text-accent' },
     error: { icon: AlertTriangle, className: 'text-danger' },
     info: { icon: Circle, className: 'text-text-muted' },

--- a/src/components/ui/ActivityRow.tsx
+++ b/src/components/ui/ActivityRow.tsx
@@ -46,7 +46,7 @@ export function ActivityRow({
                 aria-label={event}
             />
             <span className="w-24 shrink-0 font-medium text-text">{source}</span>
-            <span className="min-w-0 truncate text-text-muted">{message}</span>
+            <span className={cn('min-w-0 truncate', iconClass)}>{message}</span>
         </div>
     )
 }

--- a/src/components/ui/ActivityRow.tsx
+++ b/src/components/ui/ActivityRow.tsx
@@ -5,6 +5,7 @@ const VARIANT_CONFIG = {
     launch: { icon: CheckCircle2, className: 'text-success' },
     stop: { icon: MinusCircle, className: 'text-text-muted' },
     crashed: { icon: AlertTriangle, className: 'text-danger' },
+    restarted: { icon: CheckCircle2, className: 'text-warning' },
     iracing: { icon: CheckCircle2, className: 'text-accent' },
     error: { icon: AlertTriangle, className: 'text-danger' },
     info: { icon: Circle, className: 'text-text-muted' },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -98,8 +98,9 @@
     "no_apps_action": "Add your first app",
     "activity_panel": "Recent Activity",
     "log_events": {
-      "launch": "LAUNCH",
-      "stop": "STOP",
+      "launch": "STARTED",
+      "stop": "STOPPED",
+      "crashed": "CRASHED",
       "iracing_start": "iRACING ON",
       "iracing_stop": "iRACING OFF"
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -101,6 +101,7 @@
       "launch": "STARTED",
       "stop": "STOPPED",
       "crashed": "CRASHED",
+      "restarted": "RESTART",
       "iracing_start": "iRACING ON",
       "iracing_stop": "iRACING OFF"
     }
@@ -118,6 +119,17 @@
     "title": "Event log",
     "clear": "Clear",
     "empty": "No events yet — start iRacing to begin logging.",
+    "msg": {
+      "started": "started (pid {{pid}})",
+      "stopped": "stopped",
+      "crashed": "crashed (restart {{restart_count}}/{{max_restarts}})",
+      "crashed_simple": "crashed",
+      "restarted": "restarted (attempt {{attempt}}/{{max_restarts}}, pid {{pid}})",
+      "restarted_simple": "restarted",
+      "failed_to_start": "failed to start: {{msg}}",
+      "iracing_started": "started",
+      "iracing_stopped": "stopped"
+    },
     "types": {
       "launch": "LAUNCH",
       "stop": "STOP",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -98,8 +98,9 @@
     "no_apps_action": "Adicionar primeiro app",
     "activity_panel": "Atividade Recente",
     "log_events": {
-      "launch": "LAUNCH",
-      "stop": "STOP",
+      "launch": "INICIADO",
+      "stop": "PARADO",
+      "crashed": "TRAVADO",
       "iracing_start": "iRACING ON",
       "iracing_stop": "iRACING OFF"
     }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -101,6 +101,7 @@
       "launch": "INICIADO",
       "stop": "PARADO",
       "crashed": "TRAVADO",
+      "restarted": "RESTART",
       "iracing_start": "iRACING ON",
       "iracing_stop": "iRACING OFF"
     }
@@ -118,6 +119,17 @@
     "title": "Log de eventos",
     "clear": "Limpar",
     "empty": "Nenhum evento ainda — abra o iRacing para começar.",
+    "msg": {
+      "started": "iniciado (pid {{pid}})",
+      "stopped": "parado",
+      "crashed": "travado (reinício {{restart_count}}/{{max_restarts}})",
+      "crashed_simple": "travado",
+      "restarted": "reiniciado (tentativa {{attempt}}/{{max_restarts}}, pid {{pid}})",
+      "restarted_simple": "reiniciado",
+      "failed_to_start": "falha ao iniciar: {{msg}}",
+      "iracing_started": "iniciado",
+      "iracing_stopped": "parado"
+    },
     "types": {
       "launch": "LAUNCH",
       "stop": "STOP",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -67,7 +67,7 @@ export interface UpdateApp {
     stop_with_iracing?: boolean
 }
 
-export type LogKind = 'launch' | 'stop' | 'iracing_start' | 'iracing_stop'
+export type LogKind = 'launch' | 'stop' | 'crashed' | 'iracing_start' | 'iracing_stop'
 
 export interface LogEntry {
     seq: number

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -67,7 +67,7 @@ export interface UpdateApp {
     stop_with_iracing?: boolean
 }
 
-export type LogKind = 'launch' | 'stop' | 'crashed' | 'iracing_start' | 'iracing_stop'
+export type LogKind = 'launch' | 'stop' | 'crashed' | 'restarted' | 'iracing_start' | 'iracing_stop'
 
 export interface LogEntry {
     seq: number
@@ -75,6 +75,9 @@ export interface LogEntry {
     kind: LogKind
     app: string | null
     msg: string
+    pid: number | null
+    restart_count: number | null
+    max_restarts: number | null
 }
 
 export type AppStateType =

--- a/src/lib/command-center.ts
+++ b/src/lib/command-center.ts
@@ -35,9 +35,10 @@ export function computeReadiness(iRacingRunning: boolean, crashed: number): Read
     return 'ready'
 }
 
-export const KIND_VARIANT: Record<LogKind, 'launch' | 'stop' | 'iracing' | 'error' | 'info'> = {
+export const KIND_VARIANT: Record<LogKind, 'launch' | 'stop' | 'crashed' | 'iracing' | 'error' | 'info'> = {
     launch: 'launch',
     stop: 'stop',
+    crashed: 'crashed',
     iracing_start: 'iracing',
     iracing_stop: 'iracing',
 }

--- a/src/lib/command-center.ts
+++ b/src/lib/command-center.ts
@@ -35,10 +35,11 @@ export function computeReadiness(iRacingRunning: boolean, crashed: number): Read
     return 'ready'
 }
 
-export const KIND_VARIANT: Record<LogKind, 'launch' | 'stop' | 'crashed' | 'iracing' | 'error' | 'info'> = {
+export const KIND_VARIANT: Record<LogKind, 'launch' | 'stop' | 'crashed' | 'restarted' | 'iracing' | 'error' | 'info'> = {
     launch: 'launch',
     stop: 'stop',
     crashed: 'crashed',
+    restarted: 'restarted',
     iracing_start: 'iracing',
     iracing_stop: 'iracing',
 }
@@ -48,4 +49,40 @@ export function formatTime(ms: number): string {
     return [d.getHours(), d.getMinutes(), d.getSeconds()]
         .map((n) => String(n).padStart(2, '0'))
         .join(':')
+}
+
+import type { LogEntry } from './api'
+import i18n from '@/i18n'
+
+export function formatLogMessage(entry: LogEntry): string {
+    const t = i18n.t
+    switch (entry.kind) {
+        case 'launch':
+            return entry.pid != null ? t('log.msg.started', { pid: entry.pid }) : ''
+        case 'stop':
+            return t('log.msg.stopped')
+        case 'crashed':
+            if (entry.restart_count != null && entry.max_restarts != null) {
+                return t('log.msg.crashed', {
+                    restart_count: entry.restart_count,
+                    max_restarts: entry.max_restarts,
+                })
+            }
+            return t('log.msg.crashed_simple')
+        case 'restarted':
+            if (entry.restart_count != null && entry.max_restarts != null && entry.pid != null) {
+                return t('log.msg.restarted', {
+                    attempt: entry.restart_count,
+                    max_restarts: entry.max_restarts,
+                    pid: entry.pid,
+                })
+            }
+            return t('log.msg.restarted_simple')
+        case 'iracing_start':
+            return t('log.msg.iracing_started')
+        case 'iracing_stop':
+            return t('log.msg.iracing_stopped')
+        default:
+            return entry.msg
+    }
 }


### PR DESCRIPTION
## Summary

This PR improves app stop/start reliability with Windows Job Objects, better crash detection, localized log messages, and various watchdog fixes.

## Changes

### Backend (Rust)

- **Windows Job Objects** (`process_killer::ProcessJob`)
  - New `ProcessJob` wrapper around `CreateJobObjectW` with `KILL_ON_JOB_CLOSE`
  - Assigns spawned processes to job immediately after spawn (before PID resolution)
  - Fallback to `kill_by_exe_path` for processes that escape the job
  - Unit tests for job creation, assignment, and child-process termination

- **Launcher**
  - Prefer real PID over alive stub for Squirrel handoff detection
  - Fixes false "crashed" reports for Squirrel apps (Kapps) where the temporary stub stays alive briefly

- **Watchdog**
  - Re-check `stopping` flag inside mutex before `GiveUp`/`Restart` to fix TOCTOU race on manual stop
  - Add `reconcile_pid()`: when tracked PID dies, search for current process by `exe_path` or `track_process_name` before reporting crash or restarting
  - Pass accurate `restart_count` in `GaveUp`/`RestartFailed` events (removes race with ControllerLogic)

- **Controller / Logs**
  - Add `LogKind::Restarted` for watchdog restart events
  - Add structured fields to `LogEntry`: `pid`, `restart_count`, `max_restarts`
  - Backend no longer sends hardcoded English messages; frontend localizes all text

### Frontend (React)

- **Localized log messages**
  - New `formatLogMessage()` builds messages from `kind` + structured data
  - Supports: `started (pid)`, `stopped`, `crashed (restart X/Y)`, `restarted (attempt X/Y)`
  - Full i18n coverage in `en` and `pt-BR`

- **LogScreen**
  - CSS Grid with `grid-cols-subgrid` for perfect column alignment across all rows
  - Color-coded messages matching event type (success/warning/danger/accent)

- **Recent Activity Panel**
  - Shows up to 30 recent entries (was 6)
  - Internal scroll so panel height stays fixed
  - ActivityRow message now uses variant color

## Testing

- All 162 frontend tests passing
- All Rust tests passing (including new ProcessJob and launcher tests)

## Known Limitations

- Elevated apps (`runas`) cannot be assigned to Job Objects due to Windows privilege boundaries (`Access Denied`). These apps still fall back to `kill_by_exe_path`.
- Restart count logging for elevated apps may show attempt 1 when the process was actually on attempt 2+ due to PID reconciliation timing. This is cosmetic and does not affect restart behavior.
