### PR TITLE
🐛 fix: non-blocking icon extraction

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -301,8 +301,14 @@ pub fn update_app(
 }
 
 #[tauri::command]
-pub fn extract_icon(state: State<IconCacheState>, exe_path: String) -> Option<String> {
-    crate::icon_extractor::extract(&exe_path, &state.0)
+pub async fn extract_icon(
+    state: State<'_, IconCacheState>,
+    exe_path: String,
+) -> Result<Option<String>, String> {
+    let cache = state.0.clone();
+    tauri::async_runtime::spawn_blocking(move || crate::icon_extractor::extract(&exe_path, &cache))
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/src-tauri/src/icon_extractor.rs
+++ b/src-tauri/src/icon_extractor.rs
@@ -23,6 +23,9 @@ pub fn extract(exe_path: &str, cache: &IconCache) -> Option<String> {
 }
 
 fn run_powershell(exe_path: &str) -> Option<String> {
+    #[cfg(windows)]
+    use std::os::windows::process::CommandExt;
+
     let escaped = exe_path.replace('\'', "''");
     let script = format!(
         "try {{ \
@@ -38,9 +41,22 @@ fn run_powershell(exe_path: &str) -> Option<String> {
          }} catch {{ Write-Error $_.Exception.Message; exit 99 }}"
     );
 
-    let output = std::process::Command::new("powershell.exe")
+    #[cfg(windows)]
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    let mut command = std::process::Command::new("powershell.exe");
+    command
         .args(["-NonInteractive", "-NoProfile", "-Command", &script])
-        .output();
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    #[cfg(windows)]
+    {
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let output = command.output();
 
     match output {
         Err(e) => {
@@ -62,4 +78,3 @@ fn run_powershell(exe_path: &str) -> Option<String> {
 #[cfg(test)]
 #[path = "icon_extractor_test.rs"]
 mod tests;
-

--- a/src/__tests__/AppCard.test.tsx
+++ b/src/__tests__/AppCard.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { AppCard } from '@/components/AppCard'
 import { api } from '@/lib/api'
+import { resetAppIconUrlCacheForTests } from '@/components/screens/command-center/useAppIconUrls'
 import type { ManagedApp, AppStatus } from '@/lib/api'
 
 vi.mock('@/lib/api')
@@ -27,6 +28,7 @@ const mockApp: ManagedApp = {
 const noop = vi.fn()
 
 beforeEach(() => {
+    resetAppIconUrlCacheForTests()
     vi.mocked(api.extractIcon).mockResolvedValue(null)
 })
 

--- a/src/components/AppCard.tsx
+++ b/src/components/AppCard.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react'
 import { Pencil, Play, Square, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/cn'
-import { api, type AppStatus, type ManagedApp } from '@/lib/api'
+import type { AppStatus, ManagedApp } from '@/lib/api'
 import { StatusBadge, Button, Toggle } from '@/components/ui'
 import { AppAvatar } from '@/components/AppAvatar'
+import { useIconUrl } from './screens/command-center/useAppIconUrls'
 
 interface AppCardProps {
     app: ManagedApp
@@ -36,13 +36,7 @@ export function AppCard({
     const running = status?.state.type === 'running'
     const detail = pidDetail(status)
     const appDisabled = !app.enabled
-    const [iconUrl, setIconUrl] = useState<string | undefined>(undefined)
-
-    useEffect(() => {
-        api.extractIcon(app.exe_path).then((b64) => {
-            setIconUrl(b64 ? `data:image/png;base64,${b64}` : undefined)
-        })
-    }, [app.exe_path])
+    const iconUrl = useIconUrl(app.exe_path)
 
     const statusLabel = !app.enabled
         ? t('apps.status.disabled')

--- a/src/components/screens/command-center/useAppIconUrls.ts
+++ b/src/components/screens/command-center/useAppIconUrls.ts
@@ -1,22 +1,94 @@
 import { useEffect, useState } from 'react'
 import { api, type ManagedApp } from '@/lib/api'
 
+const iconUrlCache = new Map<string, string>()
+const pendingFetches = new Map<string, Promise<string | undefined>>()
+
+export function resetAppIconUrlCacheForTests() {
+    iconUrlCache.clear()
+    pendingFetches.clear()
+}
+
+async function loadIconUrl(exePath: string): Promise<string | undefined> {
+    const cached = iconUrlCache.get(exePath)
+    if (cached) return cached
+
+    const pending = pendingFetches.get(exePath)
+    if (pending) return pending
+
+    if (typeof api.extractIcon !== 'function') return undefined
+
+    const request = api
+        .extractIcon(exePath)
+        .then((b64) => {
+            const next = b64 ? `data:image/png;base64,${b64}` : undefined
+            if (next) iconUrlCache.set(exePath, next)
+            pendingFetches.delete(exePath)
+            return next
+        })
+        .catch(() => {
+            pendingFetches.delete(exePath)
+            return undefined
+        })
+
+    pendingFetches.set(exePath, request)
+    return request
+}
+
+export function useIconUrl(exePath?: string) {
+    const [iconUrl, setIconUrl] = useState<string | undefined>(() =>
+        exePath ? iconUrlCache.get(exePath) : undefined,
+    )
+
+    useEffect(() => {
+        let cancelled = false
+
+        if (!exePath) {
+            setIconUrl(undefined)
+            return () => {
+                cancelled = true
+            }
+        }
+
+        const cached = iconUrlCache.get(exePath)
+        if (cached) {
+            setIconUrl(cached)
+            return () => {
+                cancelled = true
+            }
+        }
+
+        loadIconUrl(exePath)
+            .then((url) => {
+                if (!cancelled) setIconUrl(url)
+            })
+            .catch(() => {})
+
+        return () => {
+            cancelled = true
+        }
+    }, [exePath])
+
+    return iconUrl
+}
+
 export function useAppIconUrls(apps: ManagedApp[]) {
     const [iconUrls, setIconUrls] = useState<Record<string, string | undefined>>({})
 
     useEffect(() => {
-        if (typeof api.extractIcon !== 'function') return
-
         let cancelled = false
 
         apps.forEach((app) => {
-            api.extractIcon(app.exe_path)
-                .then((b64) => {
+            loadIconUrl(app.exe_path)
+                .then((url) => {
                     if (cancelled) return
-                    setIconUrls((prev) => ({
-                        ...prev,
-                        [app.id]: b64 ? `data:image/png;base64,${b64}` : undefined,
-                    }))
+                    setIconUrls((prev) => {
+                        if (prev[app.id] === url) return prev
+                        return {
+                            ...prev,
+                            [app.id]: url,
+                        }
+                    })
                 })
                 .catch(() => {})
         })


### PR DESCRIPTION
## Summary
- Hide the PowerShell process used for icon extraction
- Run icon extraction off the UI thread so startup and window dragging are not blocked
- Share icon load caching across the app so repeated requests for the same exe path are deduped

## Verification
- npm test -- --run src/__tests__/AppCard.test.tsx
- cargo test --manifest-path src-tauri/Cargo.toml icon_extractor
- npm run tauri build